### PR TITLE
Fix errors with phpredis 4.0

### DIFF
--- a/rootfs/etc/owncloud.d/50-memcached.sh
+++ b/rootfs/etc/owncloud.d/50-memcached.sh
@@ -14,11 +14,11 @@ then
     fi
 
     echo "Enabling memcached config..."
+
+    occ config:system:set memcached_servers --value MEMCACHED
+    sed -i "s|'MEMCACHED'|array('${OWNCLOUD_MEMCACHED_HOST}', ${OWNCLOUD_MEMCACHED_PORT})|" /var/www/owncloud/config/config.php
     occ config:system:set memcache.distributed --value "\OC\Memcache\Memcached"
     occ config:system:set memcache.locking --value "\OC\Memcache\Memcached"
-    occ config:system:set memcached_servers --value MEMCACHED
-
-    sed -i "s|'MEMCACHED'|array('${OWNCLOUD_MEMCACHED_HOST}', ${OWNCLOUD_MEMCACHED_PORT})|" /var/www/owncloud/config/config.php
   else
     echo "Disabling memcached config..."
     occ config:system:delete memcache.distributed

--- a/rootfs/etc/owncloud.d/55-redis.sh
+++ b/rootfs/etc/owncloud.d/55-redis.sh
@@ -14,8 +14,6 @@ then
     fi
 
     echo "Enabling redis config..."
-    occ config:system:set memcache.distributed --value "\OC\Memcache\Redis"
-    occ config:system:set memcache.locking --value "\OC\Memcache\Redis"
     occ config:system:set redis --value REDIS
 
     REDIS_STRING="'host' => '${OWNCLOUD_REDIS_HOST}', 'port' => ${OWNCLOUD_REDIS_PORT}"
@@ -31,6 +29,9 @@ then
     fi
 
     sed -i "s|'REDIS'|array(${REDIS_STRING})|" /var/www/owncloud/config/config.php
+    occ config:system:set memcache.distributed --value "\OC\Memcache\Redis"
+    occ config:system:set memcache.locking --value "\OC\Memcache\Redis"
+
   else
     echo "Disabling redis config..."
     occ config:system:delete memcache.distributed


### PR DESCRIPTION
related to https://github.com/owncloud/core/pull/31228

Phpredis 4.0 throws an Exception, when the redis server could not be reached.

Prior to this PR - the first `occ config:system:set memcache.distributed --value "\OC\Memcache\Redis"` would enable redis for successiv commands. 
However the redis host/port is not yet configured and ownCloud assumes `127.0.01` as host. Thus successive `occ` commands fail with a `RedisException`.

This PR turns the order of steps, to first define the host, and then enable locking.

The change for memcache was done, to keep the flow of steps consistent.

This error was found and fixed in `owncloud-ci/base` (https://github.com/owncloud-ci/base/commit/0dea59cef8b685dcfe0400231d93db7bf569a00d). 