### PR TITLE
adjust configuration to be compatible with files_primary_s3

### DIFF
--- a/rootfs/root/owncloud/objectstore.php
+++ b/rootfs/root/owncloud/objectstore.php
@@ -13,6 +13,7 @@ $CONFIG = array (
           'secret' => '${OWNCLOUD_OBJECTSTORE_SECRET}',
         ],
         'endpoint' => '${OWNCLOUD_OBJECTSTORE_ENDPOINT}',
+        'use_path_style_endpoint' => ${OWNCLOUD_OBJECTSTORE_PATHSTYLE},
         'command.params' => [
           'PathStyle' => ${OWNCLOUD_OBJECTSTORE_PATHSTYLE},
         ]


### PR DESCRIPTION
The configuration for `files_primary_s3` differs from the previous configuration for `objectstore`

```
        'command.params' => [
          'PathStyle' => ${OWNCLOUD_OBJECTSTORE_PATHSTYLE},
        ]
```

has been moved into the `options` key:
```
'options' => [
	'use_path_style_endpoint' => true,
],
```

ref: https://github.com/owncloud/files_primary_s3/blob/master/tests/drone/scality.config.php