### PR TITLE
Correct grammar error in some of the shell scripts

### DIFF
--- a/rootfs/etc/owncloud.d/15-database.sh
+++ b/rootfs/etc/owncloud.d/15-database.sh
@@ -12,7 +12,7 @@ case ${OWNCLOUD_DB_TYPE} in
 
     if [[ $? -ne 0 && "${OWNCLOUD_DB_FAIL}" == "true" ]]
     then
-      echo "Database didn't came up in time!"
+      echo "Database didn't come up in time!"
       exit 1
     fi
     ;;
@@ -27,7 +27,7 @@ case ${OWNCLOUD_DB_TYPE} in
 
     if [[ $? -ne 0 && "${OWNCLOUD_DB_FAIL}" == "true" ]]
     then
-      echo "Database didn't came up in time!"
+      echo "Database didn't come up in time!"
       exit 1
     fi
     ;;

--- a/rootfs/etc/owncloud.d/50-memcached.sh
+++ b/rootfs/etc/owncloud.d/50-memcached.sh
@@ -9,7 +9,7 @@ then
 
     if [[ $? -ne 0 ]]
     then
-      echo "Memcached didn't came up in time!"
+      echo "Memcached didn't come up in time!"
       exit 1
     fi
 

--- a/rootfs/etc/owncloud.d/55-redis.sh
+++ b/rootfs/etc/owncloud.d/55-redis.sh
@@ -9,7 +9,7 @@ then
 
     if [[ $? -ne 0 ]]
     then
-      echo "Redis didn't came up in time!"
+      echo "Redis didn't come up in time!"
       exit 1
     fi
 


### PR DESCRIPTION
In three scripts, there's the line: "Database didn't came up in time!". This PR corrects that line to "Database didn't come up in time!".