### PR TITLE
Load objectstore config later in the processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2018-10-12
+
+* Fixed
+  * Load objectstore config later in the processing
+
 ## 2018-10-09
 
 * Added

--- a/rootfs/etc/owncloud.d/20-config.sh
+++ b/rootfs/etc/owncloud.d/20-config.sh
@@ -18,7 +18,7 @@ then
   ln -sf ${OWNCLOUD_VOLUME_CONFIG} /var/www/owncloud/config
 fi
 
-echo "Copying config file..."
+echo "Writing config file..."
 gomplate \
   -f /etc/templates/config.php \
   -o ${OWNCLOUD_VOLUME_CONFIG}/overwrite.config.php

--- a/rootfs/etc/owncloud.d/45-php.sh
+++ b/rootfs/etc/owncloud.d/45-php.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+echo "Writing objectstore config..."
+gomplate \
+  -f /etc/templates/objectstore.php \
+  -o ${OWNCLOUD_VOLUME_CONFIG}/objectstore.config.php
+
 echo "Writing php config..."
 gomplate \
   -f /etc/templates/owncloud.ini \

--- a/rootfs/etc/templates/config.php
+++ b/rootfs/etc/templates/config.php
@@ -463,29 +463,6 @@ function getConfigFromEnv() {
     }
   }
 
-  if (getenv('OWNCLOUD_OBJECTSTORE_ENABLED') && getenv('OWNCLOUD_OBJECTSTORE_ENABLED') == 'true') {
-    $config['objectstore'] = [
-      'class' => getenv('OWNCLOUD_OBJECTSTORE_CLASS'),
-      'arguments' => [
-        'bucket' => getenv('OWNCLOUD_OBJECTSTORE_BUCKET'),
-        'autocreate' => getenv('OWNCLOUD_OBJECTSTORE_AUTOCREATE'),
-        'options' => [
-          'endpoint' => getenv('OWNCLOUD_OBJECTSTORE_ENDPOINT'),
-          'version' => getenv('OWNCLOUD_OBJECTSTORE_VERSION'),
-          'region' => getenv('OWNCLOUD_OBJECTSTORE_REGION'),
-          'use_path_style_endpoint' => getenv('OWNCLOUD_OBJECTSTORE_PATHSTYLE') == 'true',
-          'command.params' => [
-            'PathStyle' => getenv('OWNCLOUD_OBJECTSTORE_PATHSTYLE') == 'true',
-          ],
-          'credentials' => [
-            'key'   => getenv('OWNCLOUD_OBJECTSTORE_KEY'),
-            'secret'  => getenv('OWNCLOUD_OBJECTSTORE_SECRET'),
-          ],
-        ],
-      ],
-    ];
-  }
-
   switch (true) {
     case getenv('OWNCLOUD_REDIS_ENABLED') && getenv('OWNCLOUD_REDIS_ENABLED') == 'true':
       $config = array_merge_recursive($config, [

--- a/rootfs/etc/templates/objectstore.php
+++ b/rootfs/etc/templates/objectstore.php
@@ -1,0 +1,32 @@
+<?php
+
+function getObjectstoreFromEnv() {
+  if (getenv('OWNCLOUD_OBJECTSTORE_ENABLED') && getenv('OWNCLOUD_OBJECTSTORE_ENABLED') == 'true') {
+    return [
+      'objectstore' => [
+        'class' => getenv('OWNCLOUD_OBJECTSTORE_CLASS'),
+        'arguments' => [
+          'bucket' => getenv('OWNCLOUD_OBJECTSTORE_BUCKET'),
+          'autocreate' => getenv('OWNCLOUD_OBJECTSTORE_AUTOCREATE'),
+          'options' => [
+            'endpoint' => getenv('OWNCLOUD_OBJECTSTORE_ENDPOINT'),
+            'version' => getenv('OWNCLOUD_OBJECTSTORE_VERSION'),
+            'region' => getenv('OWNCLOUD_OBJECTSTORE_REGION'),
+            'use_path_style_endpoint' => getenv('OWNCLOUD_OBJECTSTORE_PATHSTYLE') == 'true',
+            'command.params' => [
+              'PathStyle' => getenv('OWNCLOUD_OBJECTSTORE_PATHSTYLE') == 'true',
+            ],
+            'credentials' => [
+              'key'   => getenv('OWNCLOUD_OBJECTSTORE_KEY'),
+              'secret'  => getenv('OWNCLOUD_OBJECTSTORE_SECRET'),
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
+  return [];
+}
+
+$CONFIG = getObjectstoreFromEnv();


### PR DESCRIPTION
If it's added too early the installation of ownCloud itself fails
because the required class from files_primary_s3 is missing, moving it
somewhere behind the `OWNCLOUD_APPS_INSTALL` processing resolves this
issue.