### PR TITLE
[master] Fix chown to `www-data:root`, these are correct perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2018-10-18
+
+* Fixed
+  * Fix chown to `www-data:root`, these are correct perms
+
 ## 2018-10-12
 
 * Fixed

--- a/rootfs/etc/owncloud.d/25-chown.sh
+++ b/rootfs/etc/owncloud.d/25-chown.sh
@@ -5,33 +5,33 @@ then
   echo "Skipping chown as requested..."
 else
   echo "Fixing base perms..."
-  find /var/www/owncloud \( \! -user www-data -o \! -group www-data \) -print0 | xargs -r -0 chown www-data:www-data
+  find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root
 
   echo "Fixing data perms..."
-  find ${OWNCLOUD_VOLUME_ROOT} \( \! -user www-data -o \! -group www-data \) -print0 | xargs -r -0 chown www-data:www-data
+  find ${OWNCLOUD_VOLUME_ROOT} \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root
 
   if [[ ! ${OWNCLOUD_VOLUME_CONFIG} =~ ^${OWNCLOUD_VOLUME_ROOT} ]]
   then
     echo "Fixing config perms..."
-    find ${OWNCLOUD_VOLUME_CONFIG} \( \! -user www-data -o \! -group www-data \) -print0 | xargs -r -0 chown www-data:www-data
+    find ${OWNCLOUD_VOLUME_CONFIG} \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root
   fi
 
   if [[ ! ${OWNCLOUD_VOLUME_FILES} =~ ^${OWNCLOUD_VOLUME_ROOT} ]]
   then
     echo "Fixing file perms..."
-    find ${OWNCLOUD_VOLUME_FILES} \( \! -user www-data -o \! -group www-data \) -print0 | xargs -r -0 chown www-data:www-data
+    find ${OWNCLOUD_VOLUME_FILES} \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root
   fi
 
   if [[ ! ${OWNCLOUD_VOLUME_APPS} =~ ^${OWNCLOUD_VOLUME_ROOT} ]]
   then
     echo "Fixing app perms..."
-    find ${OWNCLOUD_VOLUME_APPS} \( \! -user www-data -o \! -group www-data \) -print0 | xargs -r -0 chown www-data:www-data
+    find ${OWNCLOUD_VOLUME_APPS} \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root
   fi
 
   if [[ ! ${OWNCLOUD_VOLUME_SESSIONS} =~ ^${OWNCLOUD_VOLUME_ROOT} ]]
   then
     echo "Fixing session perms..."
-    find ${OWNCLOUD_VOLUME_SESSIONS} \( \! -user www-data -o \! -group www-data \) -print0 | xargs -r -0 chown www-data:www-data
+    find ${OWNCLOUD_VOLUME_SESSIONS} \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root
   fi
 fi
 


### PR DESCRIPTION
So far we are always rewriting the permissions to `www-data:www-data`
while the container gets built with `www-data:root`, the latter one is
the correct value for that.