### PR TITLE
Fix apache default output

### DIFF
--- a/rootfs/etc/entrypoint.d/98-overwrite.sh
+++ b/rootfs/etc/entrypoint.d/98-overwrite.sh
@@ -4,7 +4,7 @@ export HOME="${HOME:-/var/www/owncloud}"
 export LANG="${LANG:-C}"
 
 export APACHE_ERROR_LOG="${OWNCLOUD_ERRORLOG_LOCATION:-/dev/stderr}"
-export APACHE_ACCESS_LOG="${OWNCLOUD_ACCESSLOG_LOCATION:-/dev/stderr}"
+export APACHE_ACCESS_LOG="${OWNCLOUD_ACCESSLOG_LOCATION:-/dev/stdout}"
 export APACHE_DOCUMENT_ROOT="${APACHE_DOCUMENT_ROOT:-/var/www/owncloud}"
 export APACHE_LISTEN="${APACHE_LISTEN:-8080}"
 


### PR DESCRIPTION
Currently `APACHE_ACCESS_LOG` would fallback to `stderr`. We however should fallback to `/dev/stdout`.

This PR addresses the issue