### PR TITLE
Handle mysql.utf8mb4 override as Boolean value

### DIFF
--- a/rootfs/etc/templates/config.php
+++ b/rootfs/etc/templates/config.php
@@ -331,7 +331,7 @@ function getConfigFromEnv() {
   }
 
   if (getenv('OWNCLOUD_MYSQL_UTF8MB4') != '') {
-    $config['mysql.utf8mb4'] = getenv('OWNCLOUD_MYSQL_UTF8MB4');
+    $config['mysql.utf8mb4'] = getenv('OWNCLOUD_MYSQL_UTF8MB4') == 'true';
   }
 
   if (getenv('OWNCLOUD_TEMP_DIRECTORY') != '') {


### PR DESCRIPTION
The config item mysql.utf8mb4 is a Boolean value, so the environment variable OWNCLOUD_MYSQL_UTF8MB4 must be interpreted as Boolean when being used to initialise mysql.utf8mb4.