### PR TITLE
bionic: owncloud.d: don't wait for clustered redis

### DIFF
--- a/rootfs/etc/owncloud.d/15-database.sh
+++ b/rootfs/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ then
   fi
 fi
 
-if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]]
+if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]]
 then
   echo "Waiting for Redis..."
   wait-for-it -t 60 ${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>
(cherry picked from commit 91b3d60777cba26a1858f7103fb7cad5554aa316)