### PR TITLE
Make startup script only wait for redis connection if port is not 0

### DIFF
--- a/latest/overlay/etc/owncloud.d/15-database.sh
+++ b/latest/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ then
   fi
 fi
 
-if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]]
+if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]
 then
   echo "Waiting for Redis..."
   wait-for-it -t 60 ${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}

--- a/v16.04/overlay/etc/owncloud.d/15-database.sh
+++ b/v16.04/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ then
   fi
 fi
 
-if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]]
+if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]
 then
   echo "Waiting for Redis..."
   wait-for-it -t 60 ${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}

--- a/v18.04/overlay/etc/owncloud.d/15-database.sh
+++ b/v18.04/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ then
   fi
 fi
 
-if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]]
+if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]
 then
   echo "Waiting for Redis..."
   wait-for-it -t 60 ${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}

--- a/v18.10/overlay/etc/owncloud.d/15-database.sh
+++ b/v18.10/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ then
   fi
 fi
 
-if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]]
+if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]
 then
   echo "Waiting for Redis..."
   wait-for-it -t 60 ${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}

--- a/v19.04/overlay/etc/owncloud.d/15-database.sh
+++ b/v19.04/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ then
   fi
 fi
 
-if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]]
+if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]
 then
   echo "Waiting for Redis..."
   wait-for-it -t 60 ${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}

--- a/v19.10/overlay/etc/owncloud.d/15-database.sh
+++ b/v19.10/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ then
   fi
 fi
 
-if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]]
+if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]
 then
   echo "Waiting for Redis..."
   wait-for-it -t 60 ${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}


### PR DESCRIPTION
As one also could want to use a socket connection, we should only wait for redis connection if redis port is not set to 0.