### PR TITLE
Allow OWNCLOUD_APPS_INSTALL with new major version of an app

### DIFF
--- a/v18.04/overlay/etc/owncloud.d/40-apps.sh
+++ b/v18.04/overlay/etc/owncloud.d/40-apps.sh
@@ -12,6 +12,8 @@ then
       curl -sSfLo /tmp/${NAME} -H "Accept: application/octet-stream" ${VAL}
 
       echo "Installing ${NAME} app..."
+      APPNAME=$(echo $NAME | sed -e 's/-[^-]*$//')
+      occ market:uninstall -n $APPNAME > /dev/null	# in case it is a major version upgrade
       occ market:install -n -l /tmp/${NAME}
 
       echo "Deleting ${NAME} tarball..."

--- a/v19.10/overlay/etc/owncloud.d/40-apps.sh
+++ b/v19.10/overlay/etc/owncloud.d/40-apps.sh
@@ -12,6 +12,8 @@ then
       curl -sSfLo /tmp/${NAME} -H "Accept: application/octet-stream" ${VAL}
 
       echo "Installing ${NAME} app..."
+      APPNAME=$(echo $NAME | sed -e 's/-[^-]*$//')
+      occ market:uninstall -n $APPNAME > /dev/null	# in case it is a major version upgrade
       occ market:install -n -l /tmp/${NAME}
 
       echo "Deleting ${NAME} tarball..."

--- a/v20.04/overlay/etc/owncloud.d/40-apps.sh
+++ b/v20.04/overlay/etc/owncloud.d/40-apps.sh
@@ -12,6 +12,8 @@ then
       curl -sSfLo /tmp/${NAME} -H "Accept: application/octet-stream" ${VAL}
 
       echo "Installing ${NAME} app..."
+      APPNAME=$(echo $NAME | sed -e 's/-[^-]*$//')
+      occ market:uninstall -n $APPNAME > /dev/null	# in case it is a major version upgrade
       occ market:install -n -l /tmp/${NAME}
 
       echo "Deleting ${NAME} tarball..."


### PR DESCRIPTION
A simple occ market:install does not allow to install an app, if the same app is already in the bundle, but with a lower major version.

occ market:install should have a --force option to just do it. It doesnot.

Alas, we cannot fallback to occ market:upgrade --major via shell logic, as `occ market:install` does not have any useful return code when it fails.

I suggest to run a dummy `occ market:uninstall`  first. This is harmlessly redundant in normal cases, but helps with the special case of major version upgrade.

Seen while trying
OWNCLOUD_APPS_INSTALL=https://github.com/owncloud/openidconnect/releases/download/v2.0.0RC1/openidconnect-2.0.0RC1.tar.gz
on a stock 10.6 base image containing openidconnect-1.0.0