### PR TITLE
default_socket_timeout to 3600

### DIFF
--- a/v20.04/overlay/etc/php/7.4/mods-available/owncloud.ini
+++ b/v20.04/overlay/etc/php/7.4/mods-available/owncloud.ini
@@ -7,6 +7,7 @@ post_max_size = "20G"
 
 max_execution_time = 3600
 max_input_time = 3600
+default_socket_timeout = 3600
 
 session.save_handler = "files"
 session.save_path = "/mnt/data/sessions"


### PR DESCRIPTION
Fixes https://github.com/owncloud-docker/php/issues/35