### PR TITLE
fix: fix singleuser mode env var handling

### DIFF
--- a/latest/overlay/etc/templates/config.php
+++ b/latest/overlay/etc/templates/config.php
@@ -300,7 +300,7 @@ function getConfigFromEnv() {
   }
 
   if (getenv('OWNCLOUD_SINGLEUSER') != '') {
-    $config['singleuser'] = getenv('OWNCLOUD_SINGLEUSER');
+    $config['singleuser'] = getenv('OWNCLOUD_SINGLEUSER') == 'true';
   }
 
   if (getenv('OWNCLOUD_ENABLE_CERTIFICATE_MANAGEMENT') != '') {

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -300,7 +300,7 @@ function getConfigFromEnv() {
   }
 
   if (getenv('OWNCLOUD_SINGLEUSER') != '') {
-    $config['singleuser'] = getenv('OWNCLOUD_SINGLEUSER');
+    $config['singleuser'] = getenv('OWNCLOUD_SINGLEUSER') == 'true';
   }
 
   if (getenv('OWNCLOUD_ENABLE_CERTIFICATE_MANAGEMENT') != '') {


### PR DESCRIPTION
The `singleuser` config option expects a bool value, but right now we set it as string. As a result, every value set with `OWNCLOUD_SINGLEUSER` is added as string to the config.php and will be interpreted as `true` by the oC core bool check.

This fix ensures that a bool value is set in config.php. `OWNCLOUD_SINGLEUSER=true` will set `true` while every other value of the env var will fall back to `false` in the config.php.