### PR TITLE
fix: exclude known guzzlehttp/psr7 cve

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# placeholder
+CVE-2022-24775


### PR DESCRIPTION
The vulnerability is known and already fixed in the default branch of owncloud/core. Can be reverted with the next oC release.