### PR TITLE
chore: remove unnecessary version checks

### DIFF
--- a/latest/overlay/etc/owncloud.d/40-apps.sh
+++ b/latest/overlay/etc/owncloud.d/40-apps.sh
@@ -1,69 +1,67 @@
 #!/usr/bin/env bash
 
-if dpkg --compare-versions "$(occ config:system:get version | tail -1)" "ge" "10.0"; then
-  if [[ -n "${OWNCLOUD_APPS_INSTALL}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_INSTALL}" | tr "," " "); do
-      if [[ "${VAL}" =~ ^http.* ]]; then
-        NAME=$(basename "${VAL}" | cut -d? -f1)
+if [[ -n "${OWNCLOUD_APPS_INSTALL}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_INSTALL}" | tr "," " "); do
+    if [[ "${VAL}" =~ ^http.* ]]; then
+      NAME=$(basename "${VAL}" | cut -d? -f1)
 
-        echo "Downloading ${NAME} app..."
-        curl -sSfLo "/tmp/${NAME}" -H "Accept: application/octet-stream" "${VAL}"
+      echo "Downloading ${NAME} app..."
+      curl -sSfLo "/tmp/${NAME}" -H "Accept: application/octet-stream" "${VAL}"
 
-        echo "Installing ${NAME} app..."
-        occ market:install -n -l "/tmp/${NAME}"
+      echo "Installing ${NAME} app..."
+      occ market:install -n -l "/tmp/${NAME}"
 
-        if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
-          occ market:upgrade -n -q --major -l "/tmp/${NAME}"
-        fi
-
-        echo "Deleting ${NAME} tarball..."
-        rm -f "/tmp/${NAME}"
-      else
-        if [[ ! -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
-          echo "Installing ${VAL} app..."
-          occ market:install -n "${VAL}"
-        fi
-
-        if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
-          occ market:upgrade -n -q --major "${VAL}"
-        fi
-      fi
-    done
-  fi
-
-  if [[ -n "${OWNCLOUD_APPS_ENABLE}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_ENABLE}" | tr "," " "); do
-      if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
-        echo "Enabling ${VAL} app..."
-        occ app:enable -n "${VAL}"
-      fi
-    done
-  fi
-
-  if [[ -n "${OWNCLOUD_APPS_DISABLE}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_DISABLE}" | tr "," " "); do
-      if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
-        echo "Disabling ${VAL} app..."
-        occ app:disable -n "${VAL}"
-      fi
-    done
-  fi
-
-  if [[ -n "${OWNCLOUD_APPS_UNINSTALL}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_UNINSTALL}" | tr "," " "); do
-      if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
-        echo "Uninstalling ${VAL} app..."
-        rm -r "${OWNCLOUD_VOLUME_APPS:?}/${VAL}"
+      if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
+        occ market:upgrade -n -q --major -l "/tmp/${NAME}"
       fi
 
-      if [[ -d /var/www/owncloud/apps/${VAL} ]]; then
-        echo "Uninstalling ${VAL} app..."
-        rm -r "/var/www/owncloud/apps/${VAL}"
+      echo "Deleting ${NAME} tarball..."
+      rm -f "/tmp/${NAME}"
+    else
+      if [[ ! -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
+        echo "Installing ${VAL} app..."
+        occ market:install -n "${VAL}"
       fi
-    done
-  fi
 
-  occ upgrade || true
+      if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
+        occ market:upgrade -n -q --major "${VAL}"
+      fi
+    fi
+  done
 fi
+
+if [[ -n "${OWNCLOUD_APPS_ENABLE}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_ENABLE}" | tr "," " "); do
+    if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
+      echo "Enabling ${VAL} app..."
+      occ app:enable -n "${VAL}"
+    fi
+  done
+fi
+
+if [[ -n "${OWNCLOUD_APPS_DISABLE}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_DISABLE}" | tr "," " "); do
+    if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
+      echo "Disabling ${VAL} app..."
+      occ app:disable -n "${VAL}"
+    fi
+  done
+fi
+
+if [[ -n "${OWNCLOUD_APPS_UNINSTALL}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_UNINSTALL}" | tr "," " "); do
+    if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
+      echo "Uninstalling ${VAL} app..."
+      rm -r "${OWNCLOUD_VOLUME_APPS:?}/${VAL}"
+    fi
+
+    if [[ -d /var/www/owncloud/apps/${VAL} ]]; then
+      echo "Uninstalling ${VAL} app..."
+      rm -r "/var/www/owncloud/apps/${VAL}"
+    fi
+  done
+fi
+
+occ upgrade || true
 
 true

--- a/latest/overlay/etc/owncloud.d/50-apache.sh
+++ b/latest/overlay/etc/owncloud.d/50-apache.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-if dpkg --compare-versions "$(occ config:system:get version | tail -1)" "ge" "9.0.3"; then
-  echo "Updating htaccess config..."
-  occ maintenance:update:htaccess
-fi
+echo "Updating htaccess config..."
+occ maintenance:update:htaccess
 
 echo "Writing apache config..."
 gomplate \

--- a/latest/overlay/usr/bin/cronjob
+++ b/latest/overlay/usr/bin/cronjob
@@ -9,15 +9,7 @@ if [[ -d "${OWNCLOUD_PRE_CRONJOB_PATH}" ]]; then
   done
 fi
 
-if dpkg --compare-versions "$(occ config:system:get version | tail -1)" "ge" "10.3"; then
-  occ system:cron
-else
-  if [[ "$(id -u)" == "0" ]]; then
-    su-exec www-data php -f /var/www/owncloud/cron.php
-  else
-    php -f /var/www/owncloud/cron.php
-  fi
-fi
+occ system:cron
 
 if [[ -d "${OWNCLOUD_POST_CRONJOB_PATH}" ]]; then
   for FILE in $(find "${OWNCLOUD_POST_CRONJOB_PATH}" -iname "*.sh" | sort); do

--- a/v20.04/overlay/etc/owncloud.d/40-apps.sh
+++ b/v20.04/overlay/etc/owncloud.d/40-apps.sh
@@ -1,69 +1,67 @@
 #!/usr/bin/env bash
 
-if dpkg --compare-versions "$(occ config:system:get version | tail -1)" "ge" "10.0"; then
-  if [[ -n "${OWNCLOUD_APPS_INSTALL}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_INSTALL}" | tr "," " "); do
-      if [[ "${VAL}" =~ ^http.* ]]; then
-        NAME=$(basename "${VAL}" | cut -d? -f1)
+if [[ -n "${OWNCLOUD_APPS_INSTALL}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_INSTALL}" | tr "," " "); do
+    if [[ "${VAL}" =~ ^http.* ]]; then
+      NAME=$(basename "${VAL}" | cut -d? -f1)
 
-        echo "Downloading ${NAME} app..."
-        curl -sSfLo "/tmp/${NAME}" -H "Accept: application/octet-stream" "${VAL}"
+      echo "Downloading ${NAME} app..."
+      curl -sSfLo "/tmp/${NAME}" -H "Accept: application/octet-stream" "${VAL}"
 
-        echo "Installing ${NAME} app..."
-        occ market:install -n -l "/tmp/${NAME}"
+      echo "Installing ${NAME} app..."
+      occ market:install -n -l "/tmp/${NAME}"
 
-        if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
-          occ market:upgrade -n -q --major -l "/tmp/${NAME}"
-        fi
-
-        echo "Deleting ${NAME} tarball..."
-        rm -f "/tmp/${NAME}"
-      else
-        if [[ ! -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
-          echo "Installing ${VAL} app..."
-          occ market:install -n "${VAL}"
-        fi
-
-        if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
-          occ market:upgrade -n -q --major "${VAL}"
-        fi
-      fi
-    done
-  fi
-
-  if [[ -n "${OWNCLOUD_APPS_ENABLE}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_ENABLE}" | tr "," " "); do
-      if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
-        echo "Enabling ${VAL} app..."
-        occ app:enable -n "${VAL}"
-      fi
-    done
-  fi
-
-  if [[ -n "${OWNCLOUD_APPS_DISABLE}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_DISABLE}" | tr "," " "); do
-      if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
-        echo "Disabling ${VAL} app..."
-        occ app:disable -n "${VAL}"
-      fi
-    done
-  fi
-
-  if [[ -n "${OWNCLOUD_APPS_UNINSTALL}" ]]; then
-    for VAL in $(echo "${OWNCLOUD_APPS_UNINSTALL}" | tr "," " "); do
-      if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
-        echo "Uninstalling ${VAL} app..."
-        rm -r "${OWNCLOUD_VOLUME_APPS:?}/${VAL}"
+      if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
+        occ market:upgrade -n -q --major -l "/tmp/${NAME}"
       fi
 
-      if [[ -d /var/www/owncloud/apps/${VAL} ]]; then
-        echo "Uninstalling ${VAL} app..."
-        rm -r "/var/www/owncloud/apps/${VAL}"
+      echo "Deleting ${NAME} tarball..."
+      rm -f "/tmp/${NAME}"
+    else
+      if [[ ! -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
+        echo "Installing ${VAL} app..."
+        occ market:install -n "${VAL}"
       fi
-    done
-  fi
 
-  occ upgrade || true
+      if [[ $OWNCLOUD_APPS_INSTALL_MAJOR == "true" ]]; then
+        occ market:upgrade -n -q --major "${VAL}"
+      fi
+    fi
+  done
 fi
+
+if [[ -n "${OWNCLOUD_APPS_ENABLE}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_ENABLE}" | tr "," " "); do
+    if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
+      echo "Enabling ${VAL} app..."
+      occ app:enable -n "${VAL}"
+    fi
+  done
+fi
+
+if [[ -n "${OWNCLOUD_APPS_DISABLE}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_DISABLE}" | tr "," " "); do
+    if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} || -d /var/www/owncloud/apps/${VAL} ]]; then
+      echo "Disabling ${VAL} app..."
+      occ app:disable -n "${VAL}"
+    fi
+  done
+fi
+
+if [[ -n "${OWNCLOUD_APPS_UNINSTALL}" ]]; then
+  for VAL in $(echo "${OWNCLOUD_APPS_UNINSTALL}" | tr "," " "); do
+    if [[ -d ${OWNCLOUD_VOLUME_APPS}/${VAL} ]]; then
+      echo "Uninstalling ${VAL} app..."
+      rm -r "${OWNCLOUD_VOLUME_APPS:?}/${VAL}"
+    fi
+
+    if [[ -d /var/www/owncloud/apps/${VAL} ]]; then
+      echo "Uninstalling ${VAL} app..."
+      rm -r "/var/www/owncloud/apps/${VAL}"
+    fi
+  done
+fi
+
+occ upgrade || true
 
 true

--- a/v20.04/overlay/etc/owncloud.d/50-apache.sh
+++ b/v20.04/overlay/etc/owncloud.d/50-apache.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-if dpkg --compare-versions "$(occ config:system:get version | tail -1)" "ge" "9.0.3"; then
-  echo "Updating htaccess config..."
-  occ maintenance:update:htaccess
-fi
+echo "Updating htaccess config..."
+occ maintenance:update:htaccess
 
 echo "Writing apache config..."
 gomplate \

--- a/v20.04/overlay/usr/bin/cronjob
+++ b/v20.04/overlay/usr/bin/cronjob
@@ -9,15 +9,7 @@ if [[ -d "${OWNCLOUD_PRE_CRONJOB_PATH}" ]]; then
   done
 fi
 
-if dpkg --compare-versions "$(occ config:system:get version | tail -1)" "ge" "10.3"; then
-  occ system:cron
-else
-  if [[ "$(id -u)" == "0" ]]; then
-    su-exec www-data php -f /var/www/owncloud/cron.php
-  else
-    php -f /var/www/owncloud/cron.php
-  fi
-fi
+occ system:cron
 
 if [[ -d "${OWNCLOUD_POST_CRONJOB_PATH}" ]]; then
   for FILE in $(find "${OWNCLOUD_POST_CRONJOB_PATH}" -iname "*.sh" | sort); do


### PR DESCRIPTION
Removes unnecessary `dpkg --compare-versions` version checks, as we don't build such old versions anymore.