### PR TITLE
refactor: replace su-exec/gosu with setpriv

### DIFF
--- a/latest/overlay/etc/owncloud.d/35-logging.sh
+++ b/latest/overlay/etc/owncloud.d/35-logging.sh
@@ -3,7 +3,7 @@
 if [[ ! -e ${OWNCLOUD_LOG_FILE} ]]; then
   if [[ "$(id -u)" == "0" ]]; then
     echo "Touching log file..."
-    su-exec www-data touch "${OWNCLOUD_LOG_FILE}"
+    setpriv --reuid=www-data --regid=www-data --init-groups touch "${OWNCLOUD_LOG_FILE}"
   else
     echo "Touching log file..."
     touch "${OWNCLOUD_LOG_FILE}"

--- a/latest/overlay/usr/bin/occ
+++ b/latest/overlay/usr/bin/occ
@@ -10,7 +10,7 @@ if [[ -z "${OWNCLOUD_ENTRYPOINT_INITIALIZED}" ]]; then
 fi
 
 if [[ "$(id -u)" == "0" ]]; then
-  su-exec www-data php /var/www/owncloud/occ "$@"
+  setpriv --reuid=www-data --regid=www-data --init-groups php /var/www/owncloud/occ "$@"
 else
   php /var/www/owncloud/occ "$@"
 fi

--- a/v20.04/overlay/etc/owncloud.d/35-logging.sh
+++ b/v20.04/overlay/etc/owncloud.d/35-logging.sh
@@ -3,7 +3,7 @@
 if [[ ! -e ${OWNCLOUD_LOG_FILE} ]]; then
   if [[ "$(id -u)" == "0" ]]; then
     echo "Touching log file..."
-    su-exec www-data touch "${OWNCLOUD_LOG_FILE}"
+    setpriv --reuid=www-data --regid=www-data --init-groups touch "${OWNCLOUD_LOG_FILE}"
   else
     echo "Touching log file..."
     touch "${OWNCLOUD_LOG_FILE}"

--- a/v20.04/overlay/usr/bin/occ
+++ b/v20.04/overlay/usr/bin/occ
@@ -10,7 +10,7 @@ if [[ -z "${OWNCLOUD_ENTRYPOINT_INITIALIZED}" ]]; then
 fi
 
 if [[ "$(id -u)" == "0" ]]; then
-  su-exec www-data php /var/www/owncloud/occ "$@"
+  setpriv --reuid=www-data --regid=www-data --init-groups php /var/www/owncloud/occ "$@"
 else
   php /var/www/owncloud/occ "$@"
 fi


### PR DESCRIPTION
The used tool gosu/su-exec creates a lot of noise in the security scanning (even if the CVE's are not applicable). As the same functionality can be achieved by OS  default tools this PR replaces gosu with setpriv.

```
usr/bin/su-exec (gobinary)
==========================
Total: 4 (UNKNOWN: 1, LOW: 0, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

+--------------------------------+---------------------+----------+------------------------------------+-----------------------------------+----------------------------------------------+
|            LIBRARY             |  VULNERABILITY ID   | SEVERITY |         INSTALLED VERSION          |           FIXED VERSION           |                    TITLE                     |
+--------------------------------+---------------------+----------+------------------------------------+-----------------------------------+----------------------------------------------+
| github.com/opencontainers/runc | CVE-2021-43784      | MEDIUM   | v1.0.1                             | 1.1.0                             | runc: integer overflow in                    |
|                                |                     |          |                                    |                                   | netlink bytemsg length field                 |
|                                |                     |          |                                    |                                   | allows attacker to override...               |
|                                |                     |          |                                    |                                   | -->avd.aquasec.com/nvd/cve-2021-43784        |
+                                +---------------------+          +                                    +-----------------------------------+----------------------------------------------+
|                                | CVE-2022-24769      |          |                                    | v1.1.2                            | moby: Default inheritable                    |
|                                |                     |          |                                    |                                   | capabilities for linux                       |
|                                |                     |          |                                    |                                   | container should be empty                    |
|                                |                     |          |                                    |                                   | -->avd.aquasec.com/nvd/cve-2022-24769        |
+                                +---------------------+----------+                                    +-----------------------------------+----------------------------------------------+
|                                | GHSA-v95c-p5hm-xq8f | UNKNOWN  |                                    | 1.1.0                             | An attacker with partial control             |
|                                |                     |          |                                    |                                   | over the bind mount sources of a...          |
|                                |                     |          |                                    |                                   | -->github.com/advisories/GHSA-v95c-p5hm-xq8f |
+--------------------------------+---------------------+----------+------------------------------------+-----------------------------------+----------------------------------------------+
| golang.org/x/sys               | CVE-2022-29526      | MEDIUM   | v0.0.0-20210817142637-7d9622a276b7 | 0.0.0-20220412211240-33da011f77ad | golang: syscall: faccessat                   |
|                                |                     |          |                                    |                                   | checks wrong group                           |
|                                |                     |          |                                    |                                   | -->avd.aquasec.com/nvd/cve-2022-29526        |
+--------------------------------+---------------------+----------+------------------------------------+-----------------------------------+----------------------------------------------+

```

Reference: https://github.com/tianon/gosu#setpriv

