### PR TITLE
breaking: add OWNCLOUD_TRUSTED_DOMAINS and don't rely on request headers

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -334,6 +334,9 @@ def server(config):
         "name": "server",
         "image": "registry.drone.owncloud.com/owncloud/%s:%s" % (config["repo"], config["internal"]),
         "detach": True,
+        "environment": {
+            "OWNCLOUD_TRUSTED_DOMAINS": "server",
+        },
         "commands": [
             "owncloud server",
         ],

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -76,6 +76,8 @@
   Define the default language of your ownCloud instance (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-default-language-of-your-owncloud-instance)).
 - `OWNCLOUD_DOMAIN=localhost` \
   Base domain used in `OWNCLOUD_OVERWRITE_CLI_URL` by default.
+- `OWNCLOUD_TRUSTED_DOMAINS=localhost` \
+  List of trusted domains to prevent host header poisoning (see [documentation](https://doc.owncloud.com/server/10.11/admin_manual/configuration/server/config_sample_php_parameters.html#define-list-of-trusted-domains-that-users-can-log-into)).
 - `OWNCLOUD_ENABLED_PREVIEW_PROVIDERS=` \
   Define preview providers (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-preview-providers)).
 - `OWNCLOUD_ENABLE_AVATARS=` \
@@ -291,7 +293,7 @@
 - `OWNCLOUD_SESSION_LIFETIME=` \
   Define the lifetime of a session after inactivity (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-lifetime-of-a-session-after-inactivity)).
 - `OWNCLOUD_SESSION_FORCED_LOGOUT_TIMEOUT=` \
-  Force the user to get logged out after the specified number of seconds when the tab or browser gets closed. Please read the documentation carefully before changing this option. (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#enable-to-force-user-logout)).
+  Force the user to get logged out after the specified number of seconds when the tab or browser gets closed. Please read the documentation carefully before changing this option (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#enable-to-force-user-logout)).
 - `OWNCLOUD_SESSION_SAVE_HANDLER=files` \
   Sets PHP option `session.save_handler`.
 - `OWNCLOUD_SESSION_SAVE_PATH=${OWNCLOUD_VOLUME_SESSIONS}` \

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -77,7 +77,7 @@
 - `OWNCLOUD_DOMAIN=localhost` \
   Base domain used in `OWNCLOUD_OVERWRITE_CLI_URL` by default.
 - `OWNCLOUD_TRUSTED_DOMAINS=localhost` \
-  List of trusted domains to prevent host header poisoning (see [documentation](https://doc.owncloud.com/server/10.11/admin_manual/configuration/server/config_sample_php_parameters.html#define-list-of-trusted-domains-that-users-can-log-into)).
+  List of trusted domains to prevent host header poisoning (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-list-of-trusted-domains-that-users-can-log-into)).
 - `OWNCLOUD_ENABLED_PREVIEW_PROVIDERS=` \
   Define preview providers (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-preview-providers)).
 - `OWNCLOUD_ENABLE_AVATARS=` \

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ ownCloud Docker base image.
 
 - `OWNCLOUD_DOMAIN=localhost` \
   Base domain used in `OWNCLOUD_OVERWRITE_CLI_URL` by default.
+- `OWNCLOUD_TRUSTED_DOMAINS=localhost` \
+  List of trusted domains to prevent host header poisoning (see [documentation](https://doc.owncloud.com/server/10.11/admin_manual/configuration/server/config_sample_php_parameters.html#define-list-of-trusted-domains-that-users-can-log-into)).
 - `OWNCLOUD_DB_TYPE=sqlite` \
   Identify the database used with this installation (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#identify-the-database-used-with-this-installation)).
 - `OWNCLOUD_DB_NAME=owncloud` \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ownCloud Docker base image.
 - `OWNCLOUD_DOMAIN=localhost` \
   Base domain used in `OWNCLOUD_OVERWRITE_CLI_URL` by default.
 - `OWNCLOUD_TRUSTED_DOMAINS=localhost` \
-  List of trusted domains to prevent host header poisoning (see [documentation](https://doc.owncloud.com/server/10.11/admin_manual/configuration/server/config_sample_php_parameters.html#define-list-of-trusted-domains-that-users-can-log-into)).
+  List of trusted domains to prevent host header poisoning (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-list-of-trusted-domains-that-users-can-log-into)).
 - `OWNCLOUD_DB_TYPE=sqlite` \
   Identify the database used with this installation (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#identify-the-database-used-with-this-installation)).
 - `OWNCLOUD_DB_NAME=owncloud` \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ownCloud Docker base image.
 
+> **IMPORTANT:** We had to change the behavior of the ownCloud setting for trusted domains. Instead of automatic detection, it is now required to set all trusted domains with the environment variable "OWNCLOUD_TRUSTED_DOMAINS".
+
 ## Quick reference
 
 - **Where to file issues:**\

--- a/latest/overlay/etc/entrypoint.d/10-base.sh
+++ b/latest/overlay/etc/entrypoint.d/10-base.sh
@@ -6,6 +6,9 @@ declare -x OWNCLOUD_PROTOCOL
 declare -x OWNCLOUD_DOMAIN
 [[ -z "${OWNCLOUD_DOMAIN}" ]] && OWNCLOUD_DOMAIN="localhost"
 
+declare -x OWNCLOUD_TRUSTED_DOMAINS
+[[ -z "${OWNCLOUD_TRUSTED_DOMAINS}" ]] && OWNCLOUD_TRUSTED_DOMAINS="localhost"
+
 declare -x OWNCLOUD_DEBUG
 [[ -z "${OWNCLOUD_DEBUG}" ]] && OWNCLOUD_DEBUG=""
 

--- a/latest/overlay/etc/templates/config.php
+++ b/latest/overlay/etc/templates/config.php
@@ -1,17 +1,10 @@
 <?php
 
 function getConfigFromEnv() {
-  if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-    $domain = trim(
-      explode(
-        ",",
-        $_SERVER['HTTP_X_FORWARDED_HOST']
-      )[0]
-    );
-  } else if (isset($_SERVER['SERVER_NAME'])) {
-    $domain = $_SERVER['SERVER_NAME'];
+  if (getenv('OWNCLOUD_TRUSTED_DOMAINS') != '') {
+    $domains = explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS'));
   } else {
-    $domain = 'localhost';
+    $domains = ['localhost'];
   }
 
   $config = [
@@ -27,10 +20,7 @@ function getConfigFromEnv() {
         "writable" => true
       ]
     ],
-
-    'trusted_domains' => [
-      0 => $domain
-    ],
+    'trusted_domains' => $domains,
 
     'datadirectory' => getenv('OWNCLOUD_VOLUME_FILES'),
     'dbtype' => getenv('OWNCLOUD_DB_TYPE'),

--- a/latest/overlay/etc/templates/config.php
+++ b/latest/overlay/etc/templates/config.php
@@ -1,12 +1,6 @@
 <?php
 
 function getConfigFromEnv() {
-  if (getenv('OWNCLOUD_TRUSTED_DOMAINS') != '') {
-    $domains = explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS'));
-  } else {
-    $domains = ['localhost'];
-  }
-
   $config = [
     'apps_paths' => [
       0 => [
@@ -20,7 +14,7 @@ function getConfigFromEnv() {
         "writable" => true
       ]
     ],
-    'trusted_domains' => $domains,
+    'trusted_domains' => explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS')),
 
     'datadirectory' => getenv('OWNCLOUD_VOLUME_FILES'),
     'dbtype' => getenv('OWNCLOUD_DB_TYPE'),

--- a/v20.04/overlay/etc/entrypoint.d/10-base.sh
+++ b/v20.04/overlay/etc/entrypoint.d/10-base.sh
@@ -6,6 +6,9 @@ declare -x OWNCLOUD_PROTOCOL
 declare -x OWNCLOUD_DOMAIN
 [[ -z "${OWNCLOUD_DOMAIN}" ]] && OWNCLOUD_DOMAIN="localhost"
 
+declare -x OWNCLOUD_TRUSTED_DOMAINS
+[[ -z "${OWNCLOUD_TRUSTED_DOMAINS}" ]] && OWNCLOUD_TRUSTED_DOMAINS="localhost"
+
 declare -x OWNCLOUD_DEBUG
 [[ -z "${OWNCLOUD_DEBUG}" ]] && OWNCLOUD_DEBUG=""
 

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -1,17 +1,10 @@
 <?php
 
 function getConfigFromEnv() {
-  if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-    $domain = trim(
-      explode(
-        ",",
-        $_SERVER['HTTP_X_FORWARDED_HOST']
-      )[0]
-    );
-  } else if (isset($_SERVER['SERVER_NAME'])) {
-    $domain = $_SERVER['SERVER_NAME'];
+  if (getenv('OWNCLOUD_TRUSTED_DOMAINS') != '') {
+    $domains = explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS'));
   } else {
-    $domain = 'localhost';
+    $domains = ['localhost'];
   }
 
   $config = [
@@ -27,10 +20,7 @@ function getConfigFromEnv() {
         "writable" => true
       ]
     ],
-
-    'trusted_domains' => [
-      0 => $domain
-    ],
+    'trusted_domains' => $domains,
 
     'datadirectory' => getenv('OWNCLOUD_VOLUME_FILES'),
     'dbtype' => getenv('OWNCLOUD_DB_TYPE'),

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -1,12 +1,6 @@
 <?php
 
 function getConfigFromEnv() {
-  if (getenv('OWNCLOUD_TRUSTED_DOMAINS') != '') {
-    $domains = explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS'));
-  } else {
-    $domains = ['localhost'];
-  }
-
   $config = [
     'apps_paths' => [
       0 => [
@@ -20,7 +14,7 @@ function getConfigFromEnv() {
         "writable" => true
       ]
     ],
-    'trusted_domains' => $domains,
+    'trusted_domains' => explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS')),
 
     'datadirectory' => getenv('OWNCLOUD_VOLUME_FILES'),
     'dbtype' => getenv('OWNCLOUD_DB_TYPE'),


### PR DESCRIPTION
# Don't merge immediately
We need to figure out how to best communicate this change without breaking existing deployments.

Stop putting the `Host` from the request into the `trusted_domains` config.
I added a new environment variable `OWNCLOUD_TRUSTED_DOMAINS`, which can be used to set the trusted domains value:
E.g.: `OWNCLOUD_TRUSTED_DOMAINS=localhost,example.com`
If not set it will default to `localhost`

@xoxys, with this change setting the `OWNCLOUD_TRUSTED_DOMAINS` is required, otherwise the setup will not work properly.
How do we move on with this change or do you see another way?