### PR TITLE
fix: add missing newline in the php redis config

### DIFF
--- a/latest/overlay/etc/templates/owncloud.ini.tmpl
+++ b/latest/overlay/etc/templates/owncloud.ini.tmpl
@@ -11,7 +11,7 @@ max_input_time = {{ .Env.OWNCLOUD_MAX_INPUT_TIME }}
 session.save_handler = "{{ .Env.OWNCLOUD_SESSION_SAVE_HANDLER }}"
 session.save_path = "{{ .Env.OWNCLOUD_SESSION_SAVE_PATH }}"
 
-{{- if eq .Env.OWNCLOUD_SESSION_SAVE_HANDLER "redis" -}}
+{{- if eq .Env.OWNCLOUD_SESSION_SAVE_HANDLER "redis" }}
 redis.session.locking_enabled = {{ .Env.OWNCLOUD_REDIS_SESSION_LOCKING_ENABLED }}
 redis.session.lock_wait_time = {{ .Env.OWNCLOUD_REDIS_SESSION_LOCK_WAIT_TIME }}
 redis.session.lock_retries = {{ .Env.OWNCLOUD_REDIS_SESSION_LOCK_RETRIES }}

--- a/v20.04/overlay/etc/templates/owncloud.ini.tmpl
+++ b/v20.04/overlay/etc/templates/owncloud.ini.tmpl
@@ -11,7 +11,7 @@ max_input_time = {{ .Env.OWNCLOUD_MAX_INPUT_TIME }}
 session.save_handler = "{{ .Env.OWNCLOUD_SESSION_SAVE_HANDLER }}"
 session.save_path = "{{ .Env.OWNCLOUD_SESSION_SAVE_PATH }}"
 
-{{- if eq .Env.OWNCLOUD_SESSION_SAVE_HANDLER "redis" -}}
+{{- if eq .Env.OWNCLOUD_SESSION_SAVE_HANDLER "redis" }}
 redis.session.locking_enabled = {{ .Env.OWNCLOUD_REDIS_SESSION_LOCKING_ENABLED }}
 redis.session.lock_wait_time = {{ .Env.OWNCLOUD_REDIS_SESSION_LOCK_WAIT_TIME }}
 redis.session.lock_retries = {{ .Env.OWNCLOUD_REDIS_SESSION_LOCK_RETRIES }}


### PR DESCRIPTION
Right now setting `OWNCLOUD_SESSION_SAVE_HANDLER` to `redis` leads to the following error in the logs:

```
Updating htaccess config...
PHP:  syntax error, unexpected '=' in /etc/php/7.4/cli/conf.d/99-owncloud.ini on line 12
.htaccess has been updated
Writing apache config...
Enabling cron background...
PHP:  syntax error, unexpected '=' in /etc/php/7.4/cli/conf.d/99-owncloud.ini on line 12
```

This could be narrowed down to a wrong /etc/php/7.4/cli/conf.d/99-owncloud.ini:

```
session.save_handler = "redis"
session.save_path = "/mnt/data/sessions"redis.session.locking_enabled = 1
redis.session.lock_wait_time = 20000
redis.session.lock_retries = 750
```

This PR corrects the template to generate a correct ini file.