### PR TITLE
fix: ensure trusted_domains is using an array

### DIFF
--- a/latest/overlay/etc/templates/config.php
+++ b/latest/overlay/etc/templates/config.php
@@ -4,7 +4,7 @@ function getConfigFromEnv() {
   if (getenv('OWNCLOUD_TRUSTED_DOMAINS') != '') {
     $domain =  array_map('trim', explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS')));
   } else {
-    $domain = explode(':', getenv('OWNCLOUD_DOMAIN'))[0];
+    $domain = explode(':', getenv('OWNCLOUD_DOMAIN'));
   }
 
   $config = [

--- a/latest/overlay/etc/templates/config.php
+++ b/latest/overlay/etc/templates/config.php
@@ -2,9 +2,9 @@
 
 function getConfigFromEnv() {
   if (getenv('OWNCLOUD_TRUSTED_DOMAINS') != '') {
-    $domain =  array_map('trim', explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS')));
+    $domain = array_map('trim', explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS')));
   } else {
-    $domain = explode(':', getenv('OWNCLOUD_DOMAIN'));
+    $domain = [explode(':', getenv('OWNCLOUD_DOMAIN'))[0]];
   }
 
   $config = [

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -2,9 +2,9 @@
 
 function getConfigFromEnv() {
   if (getenv('OWNCLOUD_TRUSTED_DOMAINS') != '') {
-    $domain =  array_map('trim', explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS')));
+    $domain = array_map('trim', explode(',', getenv('OWNCLOUD_TRUSTED_DOMAINS')));
   } else {
-    $domain = explode(':', getenv('OWNCLOUD_DOMAIN'))[0];
+    $domain = [explode(':', getenv('OWNCLOUD_DOMAIN'))[0]];
   }
 
   $config = [


### PR DESCRIPTION
Issue is described in https://github.com/owncloud/core/issues/40439#issuecomment-1304556277.
The fix changes `$domain` variable type from string to array if only `OWNCLOUD_DOMAIN` is provided.