### PR TITLE
fix: fix wrong volume target directory setup

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -7,15 +7,9 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
-  chown -R www-data:www-data /var/www/owncloud /mnt/data && \
-  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment  && \
+  chown -R www-data:root /var/www/owncloud /mnt/data && \
+  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chsh -s /bin/bash www-data
 
@@ -24,3 +18,9 @@ WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
   chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -7,15 +7,9 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
-  chown -R www-data:www-data /var/www/owncloud /mnt/data && \
-  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment  && \
+  chown -R www-data:root /var/www/owncloud /mnt/data && \
+  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chsh -s /bin/bash www-data
 
@@ -24,3 +18,9 @@ WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
   chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -7,15 +7,9 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
-  chown -R www-data:www-data /var/www/owncloud /mnt/data && \
-  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment  && \
+  chown -R www-data:root /var/www/owncloud /mnt/data && \
+  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chsh -s /bin/bash www-data
 
@@ -24,3 +18,9 @@ WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
   chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -7,15 +7,9 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
-  chown -R www-data:www-data /var/www/owncloud /mnt/data && \
-  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment  && \
+  chown -R www-data:root /var/www/owncloud /mnt/data && \
+  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chsh -s /bin/bash www-data
 
@@ -24,3 +18,9 @@ WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
   chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -7,15 +7,9 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
-  chown -R www-data:www-data /var/www/owncloud /mnt/data && \
-  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment  && \
+  chown -R www-data:root /var/www/owncloud /mnt/data && \
+  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chsh -s /bin/bash www-data
 
@@ -24,3 +18,9 @@ WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
   chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -7,15 +7,9 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
-  chown -R www-data:www-data /var/www/owncloud /mnt/data && \
-  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment  && \
+  chown -R www-data:root /var/www/owncloud /mnt/data && \
+  chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chsh -s /bin/bash www-data
 
@@ -24,3 +18,9 @@ WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
   chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]


### PR DESCRIPTION
Defining the default volume by `VOLUME ["/mnt/data"]` before creating the target directory resulted in an empty volume with base permissions of `root:root` and ignores the `mkdir` and `chown` commands defined later in the Dockerfile. This PR corrects the order of the `RUN` and `VOLUME` statement to properly create the volume's target directory structure and base permissions. This change only affects new setups with an empty volume. Bind mounts or existing (non-empty) Docker volumes added during deployment remain unaffected. 