### PR TITLE
Support TLS enabled Redis host

### DIFF
--- a/latest/overlay/etc/owncloud.d/15-database.sh
+++ b/latest/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ fi
 if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]; then
   echo "Waiting for Redis..."
   wait_error=false
-  wait-for-it -t "${OWNCLOUD_REDIS_STARTUP_TIMEOUT}" "${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}" || wait_error=true
+  wait-for-it -t "${OWNCLOUD_REDIS_STARTUP_TIMEOUT}" "${OWNCLOUD_REDIS_HOST#tls://}:${OWNCLOUD_REDIS_PORT}" || wait_error=true
 
   if [[ "${wait_error}" == true ]]; then
     echo "Redis didn't come up in time!"

--- a/v20.04/overlay/etc/owncloud.d/15-database.sh
+++ b/v20.04/overlay/etc/owncloud.d/15-database.sh
@@ -45,7 +45,7 @@ fi
 if [[ ${OWNCLOUD_REDIS_ENABLED} == "true" ]] && [[ ${OWNCLOUD_REDIS_SEEDS} == "" ]] && [[ ${OWNCLOUD_REDIS_PORT} != "0" ]]; then
   echo "Waiting for Redis..."
   wait_error=false
-  wait-for-it -t "${OWNCLOUD_REDIS_STARTUP_TIMEOUT}" "${OWNCLOUD_REDIS_HOST}:${OWNCLOUD_REDIS_PORT}" || wait_error=true
+  wait-for-it -t "${OWNCLOUD_REDIS_STARTUP_TIMEOUT}" "${OWNCLOUD_REDIS_HOST#tls://}:${OWNCLOUD_REDIS_PORT}" || wait_error=true
 
   if [[ "${wait_error}" == true ]]; then
     echo "Redis didn't come up in time!"


### PR DESCRIPTION
For a Redis host with TLS enabled, the hostname is expected to be prefixed with `tls://` in the configuration. However, that prefix should be omitted when checking for liveness of the Redis socket.