### PR TITLE
feat: add support for file_storage.save_version_metadata

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -292,6 +292,8 @@
   Sets the redis timeout value (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-redis-cluster-connection-details)).
 - `OWNCLOUD_REMEMBER_LOGIN_COOKIE_LIFETIME=` \
   Define the lifetime of the remember-login cookie (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-lifetime-of-the-remember-login-cookie)).
+- `OWNCLOUD_SAVE_VERSION_METADATA=` \
+  Enabled extened version metadata (see [description](https://doc.owncloud.com/server/latest/admin_manual/configuration/files/file_versioning.html#extended-version-metadata) and [documentation](https://doc.owncloud.com/server/next/admin_manual/configuration/server/config_sample_php_parameters.html#save-additional-metadata-for-versions)).
 - `OWNCLOUD_SECRET=` \
   Define ownClouds internal secret (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-ownclouds-internal-secret)).
 - `OWNCLOUD_SESSION_KEEPALIVE=` \

--- a/latest/overlay/etc/templates/config.php
+++ b/latest/overlay/etc/templates/config.php
@@ -201,6 +201,10 @@ function getConfigFromEnv() {
     $config['versions_retention_obligation'] = getenv('OWNCLOUD_VERSIONS_RETENTION_OBLIGATION');
   }
 
+  if (getenv('OWNCLOUD_SAVE_VERSION_METADATA') != '') {
+    $config['file_storage.save_version_metadata'] = getenv('OWNCLOUD_SAVE_VERSION_METADATA') === 'true';
+  }
+
   if (getenv('OWNCLOUD_UPDATE_CHECKER') != '') {
     $config['updatechecker'] = getenv('OWNCLOUD_UPDATE_CHECKER') === 'true';
   }

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -201,6 +201,10 @@ function getConfigFromEnv() {
     $config['versions_retention_obligation'] = getenv('OWNCLOUD_VERSIONS_RETENTION_OBLIGATION');
   }
 
+  if (getenv('OWNCLOUD_SAVE_VERSION_METADATA') != '') {
+    $config['file_storage.save_version_metadata'] = getenv('OWNCLOUD_SAVE_VERSION_METADATA') === 'true';
+  }
+
   if (getenv('OWNCLOUD_UPDATE_CHECKER') != '') {
     $config['updatechecker'] = getenv('OWNCLOUD_UPDATE_CHECKER') === 'true';
   }


### PR DESCRIPTION
This PR adds support for `file_storage.save_version_metadata` so it can be set via the environment variable `OWNCLOUD_SAVE_VERSION_METADATA`.