### PR TITLE
build: add ioc env variable to overwrite.php

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -366,3 +366,5 @@
   Base directory to store session files. Only used if `OWNCLOUD_SESSION_SAVE_HANDLER=file`.
 - `OWNCLOUD_PHP_DISABLE_FUNCTIONS=pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,system,phpinfo,show_source,fopen_with_path,dbmopen,dbase_open,filepro_retrieve,posix_mkfifo` \
   Some insecure PHP functions are disabled by default, and this option should not be changed for production setup. Use it with caution.
+- `OWNCLOUD_IOC_SCANNER_CONFIRMATION=` \
+  To suppress Indicators of Compromise (IoC) messages the environment variable need to be set to `EXECUTED_ON_ALL_NODES`. This feature requires a valid `OWNCLOUD_LICENSE_KEY`.

--- a/v20.04/overlay/etc/entrypoint.d/85-others.sh
+++ b/v20.04/overlay/etc/entrypoint.d/85-others.sh
@@ -225,4 +225,7 @@ declare -x OWNCLOUD_ENABLE_OIDC_REWRITE_URL
 declare -x OWNCLOUD_PHP_DISABLE_FUNCTIONS
 [[ -z "${OWNCLOUD_PHP_DISABLE_FUNCTIONS}" ]] && OWNCLOUD_PHP_DISABLE_FUNCTIONS="pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,system,phpinfo,show_source,fopen_with_path,dbmopen,dbase_open,filepro_retrieve,posix_mkfifo"
 
+declare -x OWNCLOUD_IOC_SCANNER_CONFIRMATION
+[[ -z "${OWNCLOUD_IOC_SCANNER_CONFIRMATION}" ]] && OWNCLOUD_IOC_SCANNER_CONFIRMATION=""
+
 true

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -41,6 +41,10 @@ function getConfigFromEnv() {
     'upgrade.disable-web' => true,
   ];
 
+  if (getenv('OWNCLOUD_INDICATORS_OF_COMPROMISE_SCANNER_CONFIRMATION') != '') {
+    $config['indicators-of-compromise-scanner.confirmation'] = getenv('OWNCLOUD_INDICATORS_OF_COMPROMISE_SCANNER_CONFIRMATION');
+  }
+
   if (getenv('OWNCLOUD_CORS_ALLOWED_DOMAINS') != '') {
     $config['cors.allowed-domains'] = explode(',', getenv('OWNCLOUD_CORS_ALLOWED_DOMAINS'));
   }

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -41,8 +41,8 @@ function getConfigFromEnv() {
     'upgrade.disable-web' => true,
   ];
 
-  if (getenv('OWNCLOUD_INDICATORS_OF_COMPROMISE_SCANNER_CONFIRMATION') != '') {
-    $config['indicators-of-compromise-scanner.confirmation'] = getenv('OWNCLOUD_INDICATORS_OF_COMPROMISE_SCANNER_CONFIRMATION');
+  if (getenv('OWNCLOUD_IOC_SCANNER_CONFIRMATION') != '') {
+    $config['indicators-of-compromise-scanner.confirmation'] = getenv('OWNCLOUD_IOC_SCANNER_CONFIRMATION');
   }
 
   if (getenv('OWNCLOUD_CORS_ALLOWED_DOMAINS') != '') {


### PR DESCRIPTION
Docker users can now specify via the environment
  OWNCLOUD_INDICATORS_OF_COMPROMISE_SCANNER_CONFIRMATION=EXECUTED_ON_ALL_NODES
as an alternative to
  occ c:s:s indicators-of-compromise-scanner.confirmation --value EXECUTED_ON_ALL_NODES