### PR TITLE
fix: adjust condition for redis cluster

### DIFF
--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -492,6 +492,10 @@ function getConfigFromEnv() {
         case getenv('OWNCLOUD_REDIS_SEEDS') != '':
           $config['redis.cluster']['seeds'] = explode(',', getenv('OWNCLOUD_REDIS_SEEDS'));
 
+          if (getenv('OWNCLOUD_REDIS_PASSWORD') != '') {
+            $config['redis']['password'] = getenv('OWNCLOUD_REDIS_PASSWORD');
+          }
+
           if (getenv('OWNCLOUD_REDIS_TIMEOUT') != '') {
             $config['redis.cluster']['timeout'] = (float) getenv('OWNCLOUD_REDIS_TIMEOUT');
           }
@@ -511,7 +515,7 @@ function getConfigFromEnv() {
             }
           }
 
-        case getenv('OWNCLOUD_REDIS_HOST') != '':
+        case getenv('OWNCLOUD_REDIS_HOST') != '' && getenv('OWNCLOUD_REDIS_SEEDS') == '':
           $config['redis']['host'] = getenv('OWNCLOUD_REDIS_HOST');
           $config['redis']['port'] = getenv('OWNCLOUD_REDIS_PORT');
 

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -493,7 +493,7 @@ function getConfigFromEnv() {
           $config['redis.cluster']['seeds'] = explode(',', getenv('OWNCLOUD_REDIS_SEEDS'));
 
           if (getenv('OWNCLOUD_REDIS_PASSWORD') != '') {
-            $config['redis']['password'] = getenv('OWNCLOUD_REDIS_PASSWORD');
+            $config['redis.cluster']['password'] = getenv('OWNCLOUD_REDIS_PASSWORD');
           }
 
           if (getenv('OWNCLOUD_REDIS_TIMEOUT') != '') {


### PR DESCRIPTION
When trying to setup a password-protected Redis cluster configuration by defining following in the docker-compose file:

![image001](https://github.com/owncloud-docker/base/assets/12248713/a9cceff5-6b32-4e5d-b364-012f84f68a5a)

Following is generated in config.php:

![image003](https://github.com/owncloud-docker/base/assets/12248713/5253c371-8b9b-43b2-9595-3ac4a5ac583f)

which obviously fails.

As explained by @xoxys, `OWNCLOUD_REDIS_HOST` always defaults to redis so we need to extend the condition considering the case where `OWNCLOUD_REDIS_SEEDS` is (not) set.

Additionally, we need to add the condition for the redis cluster password.