### PR TITLE
fix: remove unused web updater

### DIFF
--- a/v20.04/Dockerfile.multiarch
+++ b/v20.04/Dockerfile.multiarch
@@ -17,7 +17,8 @@ ADD overlay /
 WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
-  chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+  chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
+  rm -rf /var/www/owncloud/updater
 
 VOLUME ["/mnt/data"]
 EXPOSE 8080

--- a/v22.04/Dockerfile.multiarch
+++ b/v22.04/Dockerfile.multiarch
@@ -17,7 +17,8 @@ ADD overlay /
 WORKDIR /var/www/owncloud
 
 RUN chgrp root /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
-  chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini
+  chmod g+w /etc/apache2/sites-enabled/default.conf /etc/php/7.4/mods-available/owncloud.ini && \
+  rm -rf /var/www/owncloud/updater
 
 VOLUME ["/mnt/data"]
 EXPOSE 8080


### PR DESCRIPTION
The web updater is disabled via the config within the docker image creation.
There is absolutly no need to ship this code.