### PR TITLE
feat: add general occ subcommand to owncloud entrypoint

### DIFF
--- a/v24.04/overlay/usr/bin/owncloud
+++ b/v24.04/overlay/usr/bin/owncloud
@@ -53,6 +53,15 @@ installed)
     exit 0
   fi
   ;;
+occ)
+  for FILE in $(find /etc/owncloud.d -iname "*.sh" | sort); do
+    # shellcheck disable=SC1090,SC2086
+    source ${FILE}
+  done
+
+  shift
+  exec occ "$@"
+  ;;
 *)
   for FILE in $(find /etc/owncloud.d -iname "*.sh" | sort); do
     # shellcheck disable=SC1090,SC2086


### PR DESCRIPTION
## Summary

- Adds a new `occ` subcommand to `/usr/bin/owncloud` in the `v24.04` image
- Runs full ownCloud initialization (`/etc/owncloud.d/*.sh`) then `exec`s `occ` with forwarded arguments — without starting Apache
- Applies to any image built on `owncloud/base:24.04`

## Usage

**docker-compose.yml:**

```yaml
command: ["/usr/bin/owncloud", "occ", "<occ-command>", "<args...>"]
```

**docker run:**

```bash
docker run --rm \
  --network <oc-network> \
  -e OWNCLOUD_DB_TYPE=mysql \
  -e OWNCLOUD_DB_HOST=db \
  -e OWNCLOUD_DB_NAME=owncloud \
  -e OWNCLOUD_DB_USERNAME=owncloud \
  -e OWNCLOUD_DB_PASSWORD=owncloud \
  owncloud/server \
  /usr/bin/owncloud occ <occ-command> [args...]
```

**Examples:**

List all available occ commands:

```bash
# docker run
docker run --rm ... owncloud/server /usr/bin/owncloud occ list

# docker-compose
command: ["/usr/bin/owncloud", "occ", "list"]
```

Start the Windows Network Drive SMB listener (long-running):

```bash
# docker run
docker run \
  --network <oc-network> \
  -e OWNCLOUD_DB_TYPE=mysql \
  ... \
  owncloud/server \
  /usr/bin/owncloud occ wnd:listen myhost myshare myuser --password-file=/run/secrets/wnd_password

# docker-compose
command: ["/usr/bin/owncloud", "occ", "wnd:listen", "myhost", "myshare", "myuser", "--password-file=/run/secrets/wnd_password"]
```

## Test Plan

- [ ] Build `owncloud/base:24.04` with this change
- [ ] Run `command: ["/usr/bin/owncloud", "occ", "list"]` — verify occ command list prints, no Apache started, container exits 0
- [ ] Verify existing `server`, `install`, `migrate`, `installed` subcommands still work normally

## Related

Companion PR in `owncloud-docker/server`: owncloud-docker/server#618 (will be updated to drop the overlay once this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)