### PR TITLE
fix: remove unused legacy certs folder from Dockerfiles

### DIFF
--- a/v20.04/Dockerfile.multiarch
+++ b/v20.04/Dockerfile.multiarch
@@ -7,7 +7,7 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
+RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/sessions && \
   chown -R www-data:root /var/www/owncloud /mnt/data && \
   chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \

--- a/v22.04/Dockerfile.multiarch
+++ b/v22.04/Dockerfile.multiarch
@@ -7,7 +7,7 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
+RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/sessions && \
   chown -R www-data:root /var/www/owncloud /mnt/data && \
   chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \

--- a/v24.04/Dockerfile.multiarch
+++ b/v24.04/Dockerfile.multiarch
@@ -7,7 +7,7 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/base" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/base"
 
-RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/certs /mnt/data/sessions && \
+RUN mkdir -p /home/owncloud /var/www/owncloud /mnt/data/files /mnt/data/config /mnt/data/sessions && \
   chown -R www-data:root /var/www/owncloud /mnt/data && \
   chgrp root /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \
   chmod g+w /home/owncloud /var/run /var/lock/apache2 /var/run/apache2 /etc/environment && \


### PR DESCRIPTION
## Summary

Removes the unused `/mnt/data/certs` directory from the `mkdir -p` line in all three Dockerfiles (`v20.04`, `v22.04`, `v24.04`).

Per #482, this folder shows up in the Docker volume mount point but serves no purpose — it is confusing legacy.

## Investigation

I traced every reference to `certs` and `sessions` across the repo and the full startup flow:

- **`certs`** — appears in **exactly one place**: the Dockerfile `mkdir`. No `OWNCLOUD_VOLUME_CERTS` env var, no script/template/config reference, and it is **not** recreated at runtime. Uploaded root certs are stored by ownCloud under `files/files_external/uploads/`, confirming the issue author. ✅ Safe to remove.
- **`sessions`** — **intentionally kept**. It is the default PHP file-based `session.save_path` (`owncloud.ini.tmpl` → `session.save_path`, with `session.save_handler = "files"` by default), is wired through `50-folders.sh` → `80-session.sh`, recreated at runtime by `owncloud.d/10-folders.sh`, and chowned by `25-chown.sh`. Removing it would be functionally wrong and cosmetically ineffective (runtime recreates it anyway).

Applied to all three version directories per the repo's all-versions guidance, since the dead `certs` dir is identical in each.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)