### PR TITLE
feat(config): expose log.conditions via OWNCLOUD_LOG_CONDITIONS

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -165,6 +165,8 @@
   Define additional login buttons on the logon screen (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-additional-login-buttons-on-the-logon-screen)).
 - `OWNCLOUD_LOGIN_POLICY_ORDER=` \
   Ordered list of login policy class names. Comma-separated (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-additional-login-buttons-on-the-logon-screen)).
+- `OWNCLOUD_LOG_CONDITIONS=` \
+  Define conditional logging rules as a JSON-encoded array of condition objects, e.g. `[{"apps":["files_external"],"loglevel":0}]` (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-log-conditions)).
 - `OWNCLOUD_LOG_DATE_FORMAT=` \
   Define the log date format (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-log-date-format)).
 - `OWNCLOUD_LOG_FILE=${OWNCLOUD_VOLUME_FILES}/owncloud.log` \

--- a/v20.04/overlay/etc/templates/config.php
+++ b/v20.04/overlay/etc/templates/config.php
@@ -253,6 +253,18 @@ function getConfigFromEnv() {
     $config['log_rotate_size'] = (int) getenv('OWNCLOUD_LOG_ROTATE_SIZE');
   }
 
+  // 'log.conditions' is a list of condition maps with mixed scalar/array
+  // values (apps, users, logfile, loglevel, shared_secret), which the flat
+  // env-var idioms used elsewhere here cannot represent. It is therefore
+  // passed as a JSON-encoded array, e.g.:
+  //   OWNCLOUD_LOG_CONDITIONS='[{"apps":["files_external"],"loglevel":0}]'
+  if (getenv('OWNCLOUD_LOG_CONDITIONS') != '') {
+    $logConditions = json_decode(getenv('OWNCLOUD_LOG_CONDITIONS'), true);
+    if (is_array($logConditions)) {
+      $config['log.conditions'] = $logConditions;
+    }
+  }
+
   if (getenv('OWNCLOUD_ENABLE_PREVIEWS') != '') {
     $config['enable_previews'] = getenv('OWNCLOUD_ENABLE_PREVIEWS') === 'true';
   }

--- a/v22.04/overlay/etc/templates/config.php
+++ b/v22.04/overlay/etc/templates/config.php
@@ -253,6 +253,18 @@ function getConfigFromEnv() {
     $config['log_rotate_size'] = (int) getenv('OWNCLOUD_LOG_ROTATE_SIZE');
   }
 
+  // 'log.conditions' is a list of condition maps with mixed scalar/array
+  // values (apps, users, logfile, loglevel, shared_secret), which the flat
+  // env-var idioms used elsewhere here cannot represent. It is therefore
+  // passed as a JSON-encoded array, e.g.:
+  //   OWNCLOUD_LOG_CONDITIONS='[{"apps":["files_external"],"loglevel":0}]'
+  if (getenv('OWNCLOUD_LOG_CONDITIONS') != '') {
+    $logConditions = json_decode(getenv('OWNCLOUD_LOG_CONDITIONS'), true);
+    if (is_array($logConditions)) {
+      $config['log.conditions'] = $logConditions;
+    }
+  }
+
   if (getenv('OWNCLOUD_ENABLE_PREVIEWS') != '') {
     $config['enable_previews'] = getenv('OWNCLOUD_ENABLE_PREVIEWS') === 'true';
   }

--- a/v24.04/overlay/etc/templates/config.php
+++ b/v24.04/overlay/etc/templates/config.php
@@ -306,6 +306,18 @@ function getConfigFromEnv() {
     $config['log_rotate_size'] = (int) getenv('OWNCLOUD_LOG_ROTATE_SIZE');
   }
 
+  // 'log.conditions' is a list of condition maps with mixed scalar/array
+  // values (apps, users, logfile, loglevel, shared_secret), which the flat
+  // env-var idioms used elsewhere here cannot represent. It is therefore
+  // passed as a JSON-encoded array, e.g.:
+  //   OWNCLOUD_LOG_CONDITIONS='[{"apps":["files_external"],"loglevel":0}]'
+  if (getenv('OWNCLOUD_LOG_CONDITIONS') != '') {
+    $logConditions = json_decode(getenv('OWNCLOUD_LOG_CONDITIONS'), true);
+    if (is_array($logConditions)) {
+      $config['log.conditions'] = $logConditions;
+    }
+  }
+
   if (getenv('OWNCLOUD_ENABLE_PREVIEWS') != '') {
     $config['enable_previews'] = getenv('OWNCLOUD_ENABLE_PREVIEWS') === 'true';
   }


### PR DESCRIPTION
## What

Exposes ownCloud core's `log.conditions` config value through a new `OWNCLOUD_LOG_CONDITIONS` environment variable, parsed in `overlay/etc/templates/config.php` for all three versions (`v20.04`, `v22.04`, `v24.04`).

## Why

`log.conditions` (documented in core's `config.apps.sample.php`) is a **list of condition maps** mixing scalar and array values:

```php
'log.conditions' => [
    [
        'shared_secret' => '...',   // string
        'users'         => ['u1'],  // string[]
        'apps'          => ['a1'],  // string[]
        'logfile'       => '/x.log',// string
        'loglevel'      => 0,       // int
    ],
],
```

The flat env-var idioms already used in `config.php` (`explode()` for flat lists, `parse_str()` for a single key=value map) cannot represent a list of maps with nested arrays, so this value previously had no env-var equivalent in the image.

## How

A single JSON-encoded env var is the faithful representation:

```php
if (getenv('OWNCLOUD_LOG_CONDITIONS') != '') {
  $logConditions = json_decode(getenv('OWNCLOUD_LOG_CONDITIONS'), true);
  if (is_array($logConditions)) {
    $config['log.conditions'] = $logConditions;
  }
}
```

Example:

```bash
OWNCLOUD_LOG_CONDITIONS='[{"apps":["files_external"],"loglevel":0,"logfile":"/var/log/oc-debug.log"}]'
```

The `is_array()` guard makes malformed JSON a no-op (key left unset, core falls back to default) rather than a fatal config-generation error.

## Testing

- `php -l` clean on all three files.
- Functional test of `getConfigFromEnv()` covering: valid single condition (all five fields, types preserved), valid multi-condition list, malformed JSON (ignored), and unset (key absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)