### PR TITLE
feat(config): expose allow_subadmins via OWNCLOUD_ALLOW_SUBADMINS

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -19,7 +19,7 @@
 - `OWNCLOUD_ADMIN_USERNAME=admin` \
   ownCloud admin username.
 - `OWNCLOUD_ALLOW_SUBADMINS=` \
-  Enable or disable the subadmin (group admin) feature. Disabled by default in ownCloud core (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html)).
+  Enable or disable the subadmin (group admin) feature. Set to `true` to enable; unset leaves it disabled (ownCloud core default) (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#allow-or-disallow-the-group-administrator-subadmin-feature)).
 - `OWNCLOUD_ALLOW_USER_TO_CHANGE_DISPLAY_NAME=` \
   Allow or disallow users to change their display names (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#allow-or-disallow-users-to-change-their-display-names)).
 - `OWNCLOUD_ALLOW_USER_TO_CHANGE_MAIL_ADDRESS=` \

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -18,6 +18,8 @@
   ownCloud admin password.
 - `OWNCLOUD_ADMIN_USERNAME=admin` \
   ownCloud admin username.
+- `OWNCLOUD_ALLOW_SUBADMINS=` \
+  Enable or disable the subadmin (group admin) feature. Disabled by default in ownCloud core (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html)).
 - `OWNCLOUD_ALLOW_USER_TO_CHANGE_DISPLAY_NAME=` \
   Allow or disallow users to change their display names (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#allow-or-disallow-users-to-change-their-display-names)).
 - `OWNCLOUD_ALLOW_USER_TO_CHANGE_MAIL_ADDRESS=` \

--- a/v24.04/overlay/etc/templates/config.php
+++ b/v24.04/overlay/etc/templates/config.php
@@ -82,6 +82,10 @@ function getConfigFromEnv() {
     $config['allow_user_to_change_mail_address'] = getenv('OWNCLOUD_ALLOW_USER_TO_CHANGE_MAIL_ADDRESS') === 'true';
   }
 
+  if (getenv('OWNCLOUD_ALLOW_SUBADMINS') != '') {
+    $config['allow_subadmins'] = getenv('OWNCLOUD_ALLOW_SUBADMINS') === 'true';
+  }
+
   if (getenv('OWNCLOUD_STRICT_LOGIN_ENFORCED') != '') {
     $config['strict_login_enforced'] = getenv('OWNCLOUD_STRICT_LOGIN_ENFORCED') === 'true';
   }


### PR DESCRIPTION
## Summary

Exposes the new `allow_subadmins` ownCloud config setting through a new `OWNCLOUD_ALLOW_SUBADMINS` environment variable.

ownCloud core PR [owncloud/core#41634](https://github.com/owncloud/core/pull/41634) disables the subadmin (group-admin) feature by default as a security mitigation, introducing the `allow_subadmins` config key (defaults to `false`). This change lets operators opt the feature back in (or explicitly out) without bind-mounting a custom config.

Follows the existing boolean env-var idiom used throughout `getConfigFromEnv()` (e.g. `OWNCLOUD_VERSION_HIDE` → `version.hide`). When unset, nothing is written and core's own default applies.

**Scope:** `allow_subadmins` is an ownCloud 11 only setting, so this applies to **`v24.04` only**. `v20.04` and `v22.04` are intentionally left unchanged.

## Changes

- `v24.04/overlay/etc/templates/config.php` — map `OWNCLOUD_ALLOW_SUBADMINS` to `allow_subadmins`
- `ENVIRONMENT.md` — document the new variable

## Testing

- `php -l` passes
- `OWNCLOUD_ALLOW_SUBADMINS=true` → `allow_subadmins` is `bool(true)`
- `OWNCLOUD_ALLOW_SUBADMINS=false` → `bool(false)`
- unset → key absent (core default applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)