### PR TITLE
docs: link to org image lifecycle document

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ ownCloud Docker base image.
   [owncloud/ubuntu](https://github.com/owncloud-docker/ubuntu#environment-variables),
   [owncloud/php](https://github.com/owncloud-docker/php#environment-variables)
 
+- **Build & maintenance:**\
+  [How these images are built, scanned, updated and published](https://github.com/owncloud-docker/.github/blob/master/docs/IMAGE-LIFECYCLE.md)
+
 ## Docker Tags and respective Dockerfile links
 
 - [`20.04`](https://github.com/owncloud-docker/base/blob/master/v20.04/Dockerfile.multiarch) available as `owncloud/base:20.04`, `owncloud/base:latest`


### PR DESCRIPTION
Adds a **Build & maintenance** link in the Quick reference block pointing to the org-level [Image Lifecycle](https://github.com/owncloud-docker/.github/blob/master/docs/IMAGE-LIFECYCLE.md) document, which describes how the ownCloud Docker images are built, tagged, scanned, kept up to date and published.

The link is an absolute URL so it also resolves in the Docker Hub description (this README is published there verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)