### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-06
+
+* Added
+  * OSPO community health files (agents.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md,
+    SECURITY.md, SUPPORT.md) and README community/OSPO sections as part of the
+    Kiteworks OSPO community health rollout v2
+
 ## 2020-05-25
 
 * Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+## About this repository
+
+This repository builds the official **ownCloud base** Docker image
+([`owncloud/base`](https://hub.docker.com/r/owncloud/base)). It is not an
+application codebase — it layers ownCloud runtime defaults and an optional
+root-filesystem overlay on top of the
+[`owncloud/php`](https://github.com/owncloud-docker/php) image. See the
+[README](README.md) for build details, supported tags and usage.
+
+## Pull requests
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Rebase on the target
+  branch before submitting a PR; do not create merge commits.
+- **Signed commits**: All commits **must** be PGP/GPG signed. See
+  [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -S -s -m "your commit message"
+  ```
+- **Conventional Commits**: PR titles must follow the
+  [Conventional Commits](https://www.conventionalcommits.org/) format — this is
+  enforced by CI, and the PR title becomes the squash-merge commit message.
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by
+  `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub
+  Marketplace. Pin all actions to their full commit SHA.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/owncloud-docker/base)](https://github.com/owncloud-docker/base/graphs/contributors)
 [![Source: GitHub](https://img.shields.io/badge/source-github-blue.svg?logo=github&logoColor=white)](https://github.com/owncloud-docker/base)
 [![License: MIT](https://img.shields.io/github/license/owncloud-docker/base)](https://github.com/owncloud-docker/base/blob/master/LICENSE)
+[![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource)
 
 ownCloud Docker base image.
 
@@ -60,6 +61,60 @@ ownCloud Docker base image.
   ownCloud admin password.
 - `OWNCLOUD_LICENSE_KEY=` \
   ownCloud Enterprise License Key (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/enterprise/installation/install.html#license-keys)).
+
+## Community & Support
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+See [SUPPORT.md](SUPPORT.md) for the full list of support channels.
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow — rebase on the target
+  branch before submitting a PR.
+- **Signed commits**: All commits **must** be PGP/GPG signed and carry a DCO
+  `Signed-off-by` line (`git commit -S -s`).
+- **Conventional Commits**: PR titles must follow the
+  [Conventional Commits](https://www.conventionalcommits.org/) format — enforced
+  by CI.
+- **GitHub Actions Policy**: Workflows may only use actions owned by `owncloud`,
+  created by GitHub (`actions/*`), or verified in the GitHub Marketplace, pinned
+  to a full commit SHA.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** — see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+This repository is licensed under the permissive **MIT License**, which is already
+compatible with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+that the OSPO is adopting across the ecosystem. No relicensing or copyleft
+dependency audit is required.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: <https://github.com/orgs/owncloud/discussions>
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,94 @@
+# agents.md — base
+
+## Repository Overview
+
+This repository builds the official **ownCloud base** Docker image
+(`owncloud/base` on Docker Hub). It is the ownCloud-specific foundation layer:
+it sits on top of [`owncloud/php`](https://github.com/owncloud-docker/php) and
+adds ownCloud runtime defaults, environment-variable handling and an optional
+root-filesystem overlay. Higher-level images such as
+[`owncloud/server`](https://github.com/owncloud-docker/server) build `FROM` it.
+Images are multi-architecture and built via GitHub Actions.
+
+- **Classification:** Docker image build (base layer)
+- **Activity Status:** Active
+- **License:** MIT
+- **Language:** Dockerfile, Shell
+
+## Architecture & Key Paths
+
+- `v20.04/`, `v22.04/`, `v24.04/` — one directory per Ubuntu base release
+  - `<version>/Dockerfile.multiarch` — image definition (`FROM owncloud/php:<version>`)
+  - `<version>/overlay/` — files copied into the image root (`ADD overlay /`)
+- `ENVIRONMENT.md` — full reference of the environment variables this image
+  consumes (the README links here for the complete list)
+- `CLAUDE.md` — repository overview / instructions for Claude Code
+- `.github/workflows/main.yml` — **active** CI (build, smoke test, scan, publish)
+- `.github/workflows/lint-pr-title.yml` — Conventional-Commit PR-title enforcement
+- `.github/dependabot.yml` — weekly GitHub Actions dependency updates
+- `.renovaterc.json` — Renovate preset for Docker digest updates
+- `.editorconfig` — formatting rules (2-space indent, LF, trailing newline)
+- `.trivyignore` — accepted-CVE exclusions for the Trivy scan
+- `CHANGELOG.md` — flat, date-based changelog at repo root
+- `LICENSE` — MIT
+
+## Build & CI
+
+There is no local application build (no Node/pnpm/Make toolchain). The image is
+built by `.github/workflows/main.yml`, which calls reusable workflows hosted in
+[`owncloud-docker/ubuntu`](https://github.com/owncloud-docker/ubuntu):
+
+- Matrix builds the supported Ubuntu releases (`22.04`, `24.04`), each via
+  `v<version>/Dockerfile.multiarch`.
+- Smoke test: `php -r "echo 'OK';" | grep -q OK`.
+- Trivy vulnerability scan (`.trivyignore`).
+- On `master`: push to Docker Hub and sync the README as the image description.
+
+To build locally:
+
+```bash
+docker build -f v22.04/Dockerfile.multiarch v22.04
+```
+
+The image exposes port `8080` and declares volume `/mnt/data`.
+
+## Development Conventions
+
+- Date-based `CHANGELOG.md` at repo root — **not** a `changelog/unreleased/`
+  directory. Prepend a new `## YYYY-MM-DD` section for notable changes.
+- Conventional-Commit PR titles, enforced by `lint-pr-title.yml`.
+- `.editorconfig` governs formatting.
+- GitHub Actions are pinned to full commit SHAs.
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`),
+  verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`.
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for GitHub Actions updates; Renovate handles Docker
+  base-image digest updates.
+- Review and merge dependency PRs as part of regular maintenance.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: PR titles must follow
+  [Conventional Commits](https://www.conventionalcommits.org/); the PR title
+  becomes the squash-merge commit message and is enforced by CI.
+
+## Context for AI Agents
+
+- This is a small Docker-image packaging repo, not an application codebase.
+- The `v*/` directories are near-identical; changes usually apply to all of them.
+- The `overlay/` directories are the image root filesystem — add files there to
+  ship them in the image.
+- The active build system is GitHub Actions (`main.yml`).
+- The README is published verbatim as the Docker Hub image description — keep it
+  accurate and self-contained.
+- License is **MIT** (permissive, already compatible with Apache-2.0); no
+  copyleft dependency audit is required for relicensing.


### PR DESCRIPTION
Incorporate the Kiteworks OSPO community health rollout v2 (adapted from owncloud-docker/server#637) into the `owncloud/base` image repository.

## Changes

- **README.md**: append Community & Support, Contributing, Security and About the ownCloud OSPO sections plus an OSPO badge (additive — existing Docker reference kept since it is synced to Docker Hub)
- **agents.md**: new AI-agent context file describing the Docker build, overlay structure, CI and OSPO policy
- **CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, SUPPORT.md**: new community health files
- **CHANGELOG.md**: dated entry following the existing convention

License is **MIT** (permissive, already Apache-2.0 compatible) — no relicensing or copyleft dependency audit required. No workflow changes (GitHub Actions live SHA-pinned in `owncloud-docker/ubuntu`'s reusable workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)