### PR TITLE
feat(config): map missing config keys to env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-07-08
+
+* Added
+  * Env variable `OWNCLOUD_USER_BACKENDS` for the `user_backends` config key
+    [#490](https://github.com/owncloud-docker/base/issues/490)
+  * Env variables `OWNCLOUD_CUSTOMGROUPS_DISALLOW_ADMIN_ACCESS_ALL` and
+    `OWNCLOUD_CUSTOMGROUPS_DISALLOWED_GROUPS` for the `customgroups.*` config keys
+    [#491](https://github.com/owncloud-docker/base/issues/491)
+  * Env variable `OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP` for the
+    `loginPolicy.groupLoginPolicy.forbidMap` config key
+    [#493](https://github.com/owncloud-docker/base/issues/493)
+
 ## 2026-07-06
 
 * Added

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -70,6 +70,10 @@
   Override the desktop client download URL shown in the first-run wizard (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_apps_sample_php_parameters.html#app-firstrunwizard)).
 - `OWNCLOUD_CUSTOMCLIENT_IOS=` \
   Override the iOS client download URL shown in the first-run wizard (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_apps_sample_php_parameters.html#app-firstrunwizard)).
+- `OWNCLOUD_CUSTOMGROUPS_DISALLOWED_GROUPS=` \
+  Groups whose members have the Custom Groups app hidden from their personal settings. Comma-separated list of group names (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/user/custom_groups_app.html#overriding-default-behavior)).
+- `OWNCLOUD_CUSTOMGROUPS_DISALLOW_ADMIN_ACCESS_ALL=` \
+  When set to `true`, ownCloud admins are denied access to custom groups they are not a member of (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/user/custom_groups_app.html#overriding-default-behavior)).
 - `OWNCLOUD_DAV_CHUNK_BASE_DIR=` \
   Define the DAV chunk base directory (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-dav-chunk-base-directory)).
 - `OWNCLOUD_DAV_ENABLE_ASYNC=` \
@@ -165,6 +169,8 @@
 - `OWNCLOUD_LICENSE_CLASS=`
 - `OWNCLOUD_LOGIN_ALTERNATIVES=` \
   Define additional login buttons on the logon screen (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-additional-login-buttons-on-the-logon-screen)).
+- `OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP=` \
+  Group login policy rules as a JSON-encoded map keyed by login type (e.g. `password`, `token`), each holding `allowOnly`/`reject` lists of group names, e.g. `{"password":{"reject":["admin"]}}`. Requires the group login policy in `OWNCLOUD_LOGIN_POLICY_ORDER` (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/user/login_policies.html)).
 - `OWNCLOUD_LOGIN_POLICY_ORDER=` \
   Ordered list of login policy class names. Comma-separated (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-additional-login-buttons-on-the-logon-screen)).
 - `OWNCLOUD_LOG_CONDITIONS=` \
@@ -444,6 +450,8 @@
   Define whether or not to enable automatic update of market apps (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-whether-or-not-to-enable-automatic-update-of-market-apps)).
 - `OWNCLOUD_USE_RELATIVE_DOMAIN_NAME=` \
   Use only the short hostname (no FQDN) in `status.php` (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#show-or-hide-the-server-hostname-in-status-php)).
+- `OWNCLOUD_USER_BACKENDS=` \
+  External user authentication backends as a JSON-encoded list of `{"class":..., "arguments":[...]}` objects (provided by the `user_external` app), e.g. `[{"class":"OC_User_IMAP","arguments":["{imap.example.com:993/imap/ssl}"]}]` (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/user/user_auth_ftp_smb_imap.html)).
 - `OWNCLOUD_USER_LDAP_ENABLE_MEDIAL_SEARCH=` \
   Enable medial search in the LDAP user backend (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_apps_sample_php_parameters.html#app-ldap)).
 - `OWNCLOUD_USER_SEARCH_MIN_LENGTH=` \

--- a/v24.04/overlay/etc/templates/config.php
+++ b/v24.04/overlay/etc/templates/config.php
@@ -603,8 +603,32 @@ function getConfigFromEnv() {
     $config['loginPolicy.order'] = explode(',', getenv('OWNCLOUD_LOGIN_POLICY_ORDER'));
   }
 
+  // 'loginPolicy.groupLoginPolicy.forbidMap' is a nested map keyed by login
+  // type (e.g. 'password', 'token', or an auth-module class), each holding
+  // 'allowOnly'/'reject' lists of group names. The flat env-var idioms cannot
+  // represent it, so it is passed as a JSON-encoded map, e.g.:
+  //   OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP='{"password":{"reject":["admin"]}}'
+  if (getenv('OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP') != '') {
+    $forbidMap = json_decode(getenv('OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP'), true);
+    if (is_array($forbidMap)) {
+      $config['loginPolicy.groupLoginPolicy.forbidMap'] = $forbidMap;
+    }
+  }
+
   if (getenv('OWNCLOUD_OPENSSL_CONFIG') != '') {
     $config['openssl'] = ['config' => getenv('OWNCLOUD_OPENSSL_CONFIG')];
+  }
+
+  // 'user_backends' is a list of external user-auth backend definitions, each
+  // a map of 'class' plus an 'arguments' list (provided by the user_external
+  // app). The flat env-var idioms cannot represent it, so it is passed as a
+  // JSON-encoded array, e.g.:
+  //   OWNCLOUD_USER_BACKENDS='[{"class":"OC_User_IMAP","arguments":["{imap.example.com:993/imap/ssl}"]}]'
+  if (getenv('OWNCLOUD_USER_BACKENDS') != '') {
+    $userBackends = json_decode(getenv('OWNCLOUD_USER_BACKENDS'), true);
+    if (is_array($userBackends)) {
+      $config['user_backends'] = $userBackends;
+    }
   }
 
   if (getenv('OWNCLOUD_DB_PLATFORM') != '') {
@@ -614,6 +638,15 @@ function getConfigFromEnv() {
   // app: admin_audit
   if (getenv('OWNCLOUD_ADMIN_AUDIT_GROUPS') != '') {
     $config['admin_audit.groups'] = explode(',', getenv('OWNCLOUD_ADMIN_AUDIT_GROUPS'));
+  }
+
+  // app: customgroups
+  if (getenv('OWNCLOUD_CUSTOMGROUPS_DISALLOW_ADMIN_ACCESS_ALL') != '') {
+    $config['customgroups.disallow-admin-access-all'] = getenv('OWNCLOUD_CUSTOMGROUPS_DISALLOW_ADMIN_ACCESS_ALL') === 'true';
+  }
+
+  if (getenv('OWNCLOUD_CUSTOMGROUPS_DISALLOWED_GROUPS') != '') {
+    $config['customgroups.disallowed-groups'] = explode(',', getenv('OWNCLOUD_CUSTOMGROUPS_DISALLOWED_GROUPS'));
   }
 
   // app: files_antivirus


### PR DESCRIPTION
## Summary

Adds environment-variable mappings for three ownCloud `config.php` keys that were documented/available as config keys but had no corresponding env var in the image config template.

| Env var | config.php key | Issue |
|---|---|---|
| `OWNCLOUD_USER_BACKENDS` | `user_backends` | #490 |
| `OWNCLOUD_CUSTOMGROUPS_DISALLOW_ADMIN_ACCESS_ALL` | `customgroups.disallow-admin-access-all` | #491 |
| `OWNCLOUD_CUSTOMGROUPS_DISALLOWED_GROUPS` | `customgroups.disallowed-groups` | #491 |
| `OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP` | `loginPolicy.groupLoginPolicy.forbidMap` | #493 |

## Details

- **`user_backends`** and **`loginPolicy.groupLoginPolicy.forbidMap`** are nested/named arrays that the flat `getenv → string`/`explode()` idioms cannot express, so they use the **JSON-encoded pattern** already established for `OWNCLOUD_LOG_CONDITIONS` (`json_decode(...)` guarded by `is_array`). Invalid JSON is silently ignored, leaving the key unset.
- **`customgroups.*`** are two simple keys: a boolean and a comma-separated list — mapped with the existing `=== 'true'` and `explode(',', ...)` idioms. These are the only two `customgroups.` config keys (verified against the `owncloud/customgroups` app source).
- Mappings are added to **`v24.04` only**, matching the established convention that `v20.04`/`v22.04` templates are frozen and only `22.04`/`24.04` are built by CI.
- `ENVIRONMENT.md` gains alphabetically-placed entries for each var; `CHANGELOG.md` gets a dated section.

Config-key shapes were validated against ownCloud org repos (`owncloud/core`, `owncloud/docs-server`, `owncloud/customgroups`, `user_external`).

## Verification

- `php -l` passes on all three templates.
- Behavioral check via `php -r` dumping `$CONFIG`: each key appears with the correct shape when its var is set, is **absent** when unset, and invalid JSON is safely ignored.

Closes #490
Closes #491
Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)