### PR TITLE
feat(config): support multiple memcached servers via OWNCLOUD_MEMCACHED_SERVERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   * Env variable `OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP` for the
     `loginPolicy.groupLoginPolicy.forbidMap` config key
     [#493](https://github.com/owncloud-docker/base/issues/493)
+  * Env variable `OWNCLOUD_MEMCACHED_SERVERS` to define multiple memcached
+    servers (and optional per-server weights)
+    [#489](https://github.com/owncloud-docker/base/issues/489)
 
 ## 2026-07-06
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -227,6 +227,8 @@
   Define connection options for memcached (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-connection-options-for-memcached)).
 - `OWNCLOUD_MEMCACHED_PORT=11211` \
   Defines the ports for memcached (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-server-details-for-memcached-servers-to-use-for-memory-caching)).
+- `OWNCLOUD_MEMCACHED_SERVERS=` \
+  Define multiple memcached servers as a JSON-encoded list of `[host, port]` or `[host, port, weight]` tuples, e.g. `[["mem1",11211,33],["mem2",11211]]`. Overrides the single-server `OWNCLOUD_MEMCACHED_HOST`/`OWNCLOUD_MEMCACHED_PORT` pair when set. Note that the container startup readiness check still probes only `OWNCLOUD_MEMCACHED_HOST`:`OWNCLOUD_MEMCACHED_PORT` (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-server-details-for-memcached-servers-to-use-for-memory-caching)).
 - `OWNCLOUD_MEMCACHED_STARTUP_TIMEOUT=180` \
   Time to wait for a successful connection to the memcached service on container startup.
 - `OWNCLOUD_MEMCACHE_LOCAL=${OWNCLOUD_CACHING_CLASS:-\\OC\\Memcache\\APCu}` \

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -228,7 +228,7 @@
 - `OWNCLOUD_MEMCACHED_PORT=11211` \
   Defines the ports for memcached (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-server-details-for-memcached-servers-to-use-for-memory-caching)).
 - `OWNCLOUD_MEMCACHED_SERVERS=` \
-  Define multiple memcached servers as a JSON-encoded list of `[host, port]` or `[host, port, weight]` tuples, e.g. `[["mem1",11211,33],["mem2",11211]]`. Overrides the single-server `OWNCLOUD_MEMCACHED_HOST`/`OWNCLOUD_MEMCACHED_PORT` pair when set. Note that the container startup readiness check still probes only `OWNCLOUD_MEMCACHED_HOST`:`OWNCLOUD_MEMCACHED_PORT` (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-server-details-for-memcached-servers-to-use-for-memory-caching)).
+  Define multiple memcached servers as a JSON-encoded list of `[host, port]` or `[host, port, weight]` tuples, e.g. `[["mem1",11211,33],["mem2",11211]]`. Overrides the single-server `OWNCLOUD_MEMCACHED_HOST`/`OWNCLOUD_MEMCACHED_PORT` pair when set (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-server-details-for-memcached-servers-to-use-for-memory-caching)).
 - `OWNCLOUD_MEMCACHED_STARTUP_TIMEOUT=180` \
   Time to wait for a successful connection to the memcached service on container startup.
 - `OWNCLOUD_MEMCACHE_LOCAL=${OWNCLOUD_CACHING_CLASS:-\\OC\\Memcache\\APCu}` \

--- a/v24.04/overlay/etc/owncloud.d/15-database.sh
+++ b/v24.04/overlay/etc/owncloud.d/15-database.sh
@@ -31,7 +31,7 @@ case ${OWNCLOUD_DB_TYPE} in
   ;;
 esac
 
-if [[ ${OWNCLOUD_MEMCACHED_ENABLED} == "true" ]]; then
+if [[ ${OWNCLOUD_MEMCACHED_ENABLED} == "true" ]] && [[ ${OWNCLOUD_MEMCACHED_SERVERS} == "" ]]; then
   echo "Waiting for Memcached..."
   wait_error=false
   wait-for-it -t "${OWNCLOUD_MEMCACHED_STARTUP_TIMEOUT}" "${OWNCLOUD_MEMCACHED_HOST}":"${OWNCLOUD_MEMCACHED_PORT}" || wait_error=true

--- a/v24.04/overlay/etc/templates/config.php
+++ b/v24.04/overlay/etc/templates/config.php
@@ -906,16 +906,30 @@ function getConfigFromEnv() {
 
       break;
     case getenv('OWNCLOUD_MEMCACHED_ENABLED') && getenv('OWNCLOUD_MEMCACHED_ENABLED') === 'true':
+      // 'memcached_servers' is a list of [host, port] or [host, port, weight]
+      // tuples. The flat env-var idioms cannot express multiple servers or a
+      // weight, so multiple servers are passed as a JSON-encoded array, e.g.:
+      //   OWNCLOUD_MEMCACHED_SERVERS='[["mem1",11211,33],["mem2",11211]]'
+      // When unset, fall back to the single OWNCLOUD_MEMCACHED_HOST/_PORT pair.
+      $memcachedServers = [
+        [
+          getenv('OWNCLOUD_MEMCACHED_HOST'),
+          getenv('OWNCLOUD_MEMCACHED_PORT'),
+        ],
+      ];
+
+      if (getenv('OWNCLOUD_MEMCACHED_SERVERS') != '') {
+        $servers = json_decode(getenv('OWNCLOUD_MEMCACHED_SERVERS'), true);
+        if (is_array($servers)) {
+          $memcachedServers = $servers;
+        }
+      }
+
       $config = array_merge_recursive($config, [
         'memcache.distributed' => '\OC\Memcache\Memcached',
         'memcache.locking' => '\OC\Memcache\Memcached',
 
-        'memcached_servers' => [
-          [
-            getenv('OWNCLOUD_MEMCACHED_HOST'),
-            getenv('OWNCLOUD_MEMCACHED_PORT'),
-          ],
-        ],
+        'memcached_servers' => $memcachedServers,
       ]);
 
       if (getenv('OWNCLOUD_MEMCACHED_OPTIONS') != '') {


### PR DESCRIPTION
## Summary

Implements **Option A** from the discussion on #489: adds a single JSON-encoded env var to define **multiple memcached servers** (with optional per-server weights).

Previously the memcached block in `v24.04/overlay/etc/templates/config.php` hard-coded exactly one `[host, port]` pair from `OWNCLOUD_MEMCACHED_HOST` / `OWNCLOUD_MEMCACHED_PORT`, while ownCloud core's `memcached_servers` accepts a list of `[host, port]` or `[host, port, weight]` tuples.

## Details

- New var **`OWNCLOUD_MEMCACHED_SERVERS`** — a JSON-encoded array of tuples, decoded with `json_decode(...)` guarded by `is_array` (the same pattern as `OWNCLOUD_LOG_CONDITIONS`):
  ```
  OWNCLOUD_MEMCACHED_SERVERS='[["mem1",11211,33],["mem2",11211]]'
  ```
- **Backward compatible**: when the var is unset — or the JSON is invalid — it falls back to the existing single `[HOST, PORT]` pair. Existing single-server deployments are completely unaffected (var is unset by default).
- **v24.04 only**, matching the convention that `v20.04`/`v22.04` templates are frozen and only `22.04`/`24.04` are built by CI.
- The container startup wait for memcached (`wait-for-it` in `15-database.sh`) is **skipped when `OWNCLOUD_MEMCACHED_SERVERS` is set**, mirroring how the redis wait is skipped when `OWNCLOUD_REDIS_SEEDS` is set. This avoids the container failing to start by probing the default single `HOST:PORT` when the real cache is defined via the multi-server list.

## Verification

- `php -l` passes; `bash -n 15-database.sh` passes.
- Behavioral check via `php -r` dumping `$CONFIG['memcached_servers']`:
  - multi-server JSON → two-server list with weight preserved;
  - unset → single `['memcached','11211']` fallback;
  - invalid JSON → single-pair fallback (guarded);
  - `memcache.distributed`/`memcache.locking` still `\OC\Memcache\Memcached`.
- Startup-wait guard (stubbed `wait-for-it`): `ENABLED=true`+`SERVERS` unset → waits; `ENABLED=true`+`SERVERS` set → skipped; `ENABLED=false` → skipped.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)