### PR TITLE
feat(config): expose openid-connect via OWNCLOUD_OPENID_CONNECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-09
+
+* Added
+  * Env variable `OWNCLOUD_OPENID_CONNECT` for the `openid-connect` app config key
+    [#492](https://github.com/owncloud-docker/base/issues/492)
+
 ## 2026-07-08
 
 * Added

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -274,6 +274,8 @@
   Maximum number of concurrent UploadPart operations allowed during the multipart upload (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/files/external_storage/s3_compatible_object_storage_as_primary.html)).
 - `OWNCLOUD_OBJECTSTORE_AVAILABLE_STORAGE=` \
   Indicates available storage size in the objectstore in bytes (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/files/external_storage/s3_compatible_object_storage_as_primary.html)).
+- `OWNCLOUD_OPENID_CONNECT=` \
+  OpenID Connect (`openid-connect`) app configuration as a JSON-encoded object, e.g. `{"provider-url":"https://idp.example.net","client-id":"...","client-secret":"...","loginButtonName":"OpenID Connect"}`. Supports the full nested structure (`provider-params`, `auto-provision`, ...) (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_apps_sample_php_parameters.html#app-openid-connect-oidc)).
 - `OWNCLOUD_OPENSSL_CONFIG=` \
   Path to a custom `openssl.cnf` file, e.g. when using a custom PKI or CA in the container (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-default-cipher-for-encrypting-files)).
 - `OWNCLOUD_OPERATION_MODE=` \

--- a/v24.04/overlay/etc/templates/config.php
+++ b/v24.04/overlay/etc/templates/config.php
@@ -676,6 +676,19 @@ function getConfigFromEnv() {
     $config['customclient_ios'] = getenv('OWNCLOUD_CUSTOMCLIENT_IOS');
   }
 
+  // app: openidconnect
+  // 'openid-connect' is a deeply nested associative array (provider-url,
+  // client-id/secret, scopes, provider-params, auto-provision, ...) that the
+  // flat env-var idioms cannot represent, so it is passed as a JSON-encoded
+  // object, e.g.:
+  //   OWNCLOUD_OPENID_CONNECT='{"provider-url":"https://idp.example.net","client-id":"...","client-secret":"...","loginButtonName":"OpenID Connect"}'
+  if (getenv('OWNCLOUD_OPENID_CONNECT') != '') {
+    $openIdConnect = json_decode(getenv('OWNCLOUD_OPENID_CONNECT'), true);
+    if (is_array($openIdConnect)) {
+      $config['openid-connect'] = $openIdConnect;
+    }
+  }
+
   // app: user_ldap
   if (getenv('OWNCLOUD_LDAP_IGNORE_NAMING_RULES') != '') {
     $config['ldapIgnoreNamingRules'] = getenv('OWNCLOUD_LDAP_IGNORE_NAMING_RULES') === 'true';


### PR DESCRIPTION
## Summary

Adds an environment variable for the `openidconnect` app's `openid-connect` config key, which had no env-var mapping — OIDC could only be configured by mounting a custom `config.php` or via `occ`. (The pre-existing `OWNCLOUD_ENABLE_OIDC_REWRITE_URL` is an unrelated Apache rewrite toggle, not the app config.)

Requested in #492 — reopened by @DeepDiver1975 confirming the mapping is still needed.

## Details

- New var **`OWNCLOUD_OPENID_CONNECT`** — a JSON-encoded object decoded into `$config['openid-connect']`:
  ```
  OWNCLOUD_OPENID_CONNECT='{"provider-url":"https://idp.example.net","client-id":"...","client-secret":"...","loginButtonName":"OpenID Connect"}'
  ```
- `openid-connect` is a **deeply nested** associative array (`scopes`, `provider-params`, `auto-provision.update`, ...) that the flat env-var idioms cannot represent. Decoding to an array here is **required**, not just convenient: `Client::getOpenIdConfig()` (`lib/Client.php`) reads the system-config value via `getSystemValue('openid-connect', null)` and consumes it directly with array access (`['auto-provision']`, `['mode']`, ...) — the app only `json_decode`s the *app-value* (DB) path, so a raw JSON string in system config would break it. We reuse the `json_decode` + `is_array` guard pattern already established for `OWNCLOUD_LOG_CONDITIONS` / `OWNCLOUD_USER_BACKENDS`. Invalid JSON is ignored, leaving the key unset.
- Shape validated against the `owncloud/openidconnect` app source (`lib/Client.php`, app README) and the OIDC admin docs.
- **v24.04 only.** The recent env-var additions (`OWNCLOUD_USER_BACKENDS` #490, `OWNCLOUD_LOGIN_POLICY_GROUP_FORBID_MAP` #493, `OWNCLOUD_CUSTOMGROUPS_*` #491) all landed in `v24.04` only; `v20.04`/`v22.04` retain their older vars but no longer receive new ones, and CI builds only `22.04`/`24.04`.

> **Note:** the JSON payload contains `client-secret`. It is handled the same way as other secrets already exposed here (LDAP, S3 keys), so no new exposure class — but treat the env var as sensitive and source it from a secrets store where possible.

## Verification

- `php -l` passes.
- Behavioral check via `php -r` dumping `$CONFIG['openid-connect']`: a nested payload (`scopes` list, `provider-params`, `auto-provision.update`) round-trips intact; key is **absent** when the var is unset; invalid JSON safely falls back to unset.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
